### PR TITLE
Support for chrome / electron / nw.js apps and extensions

### DIFF
--- a/src/browser/extension/background/messaging.js
+++ b/src/browser/extension/background/messaging.js
@@ -64,6 +64,10 @@ chrome.runtime.onMessageExternal.addListener(messaging);
 
 export function toContentScript(action) {
   chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {
-    chrome.tabs.sendMessage(store.tabId, {action: action}, function(response) {});
+    if (store.tabId in connections) {
+      connections[ store.tabId ].postMessage({action: action});
+    } else {
+      chrome.tabs.sendMessage(store.tabId, {action: action});
+    }
   });
 }

--- a/src/browser/extension/background/messaging.js
+++ b/src/browser/extension/background/messaging.js
@@ -49,8 +49,10 @@ function messaging(request, sender) {
     if (request.payload) store.liftedStore.setState(request.payload);
     if (request.init) {
       store.tabId = tabId;
-      chrome.contextMenus.update(MENU_DEVTOOLS, {documentUrlPatterns: [sender.url], enabled: true});
-      chrome.pageAction.show(tabId);
+      if (typeof tabId === 'number') {
+        chrome.contextMenus.update(MENU_DEVTOOLS, {documentUrlPatterns: [sender.url], enabled: true});
+        chrome.pageAction.show(tabId);
+      }
     }
     if (tabId in connections) {
       connections[ tabId ].postMessage(request);

--- a/src/browser/extension/background/messaging.js
+++ b/src/browser/extension/background/messaging.js
@@ -40,8 +40,8 @@ chrome.runtime.onConnect.addListener(function(port) {
 
 // Receive message from content script and relay to the devTools page
 function messaging(request, sender) {
-  if (sender.tab) {
-    const tabId = sender.tab.id;
+  const tabId = sender.tab ? sender.tab.id : sender.id;
+  if (tabId) {
     if (request.type === 'PAGE_UNLOADED') {
       if (connections[ tabId ]) sendNAMessage(connections[ tabId ]);
       return true;

--- a/src/browser/extension/background/messaging.js
+++ b/src/browser/extension/background/messaging.js
@@ -13,11 +13,11 @@ chrome.runtime.onConnect.addListener(function(port) {
 
   function extensionListener(message) {
     if (message.name === 'init') {
+      connections[message.tabId] = port;
       if (message.tabId !== store.tabId) {
         sendNAMessage(port);
         return;
       }
-      connections[message.tabId] = port;
       connections[message.tabId].postMessage({
         payload: store.liftedStore.getState(),
         source: 'redux-page'
@@ -39,7 +39,7 @@ chrome.runtime.onConnect.addListener(function(port) {
 });
 
 // Receive message from content script and relay to the devTools page
-chrome.runtime.onMessage.addListener(function(request, sender) {
+function messaging(request, sender) {
   if (sender.tab) {
     const tabId = sender.tab.id;
     if (request.type === 'PAGE_UNLOADED') {
@@ -57,7 +57,10 @@ chrome.runtime.onMessage.addListener(function(request, sender) {
     }
   }
   return true;
-});
+}
+
+chrome.runtime.onMessage.addListener(messaging);
+chrome.runtime.onMessageExternal.addListener(messaging);
 
 export function toContentScript(action) {
   chrome.tabs.query({active: true, currentWindow: true}, function(tabs) {

--- a/src/browser/extension/devpanel/index.js
+++ b/src/browser/extension/devpanel/index.js
@@ -54,14 +54,7 @@ chrome.devtools.inspectedWindow.eval(
   'devToolsExtension',
   function(result, isException) {
     if (isException) {
-      chrome.devtools.inspectedWindow.reload({
-        injectedScript: 'setTimeout( function () {' +
-        'var s = document.createElement(\'script\');' +
-        's.src = \'' + chrome.extension.getURL('js/content.bundle.js') + '\';' +
-        's.onload = function() { this.parentNode.removeChild(this); };' +
-        'document.documentElement.appendChild(s);' +
-        '}, 0);'
-      });
+      require('./remote');
     }
   }
 );

--- a/src/browser/extension/devpanel/index.js
+++ b/src/browser/extension/devpanel/index.js
@@ -49,17 +49,20 @@ backgroundPageConnection.onMessage.addListener((message) => {
   showDevTools();
 });
 
-backgroundPageConnection.postMessage({
-  name: 'init',
-  tabId: chrome.devtools.inspectedWindow.tabId
-});
+function init(defaultID) {
+  backgroundPageConnection.postMessage({
+    name: 'init',
+    tabId: chrome.devtools.inspectedWindow.tabId || defaultID
+  });
+}
 
-// If devToolsExtension wasn't injected, reload the page and inject it
+// If devToolsExtension wasn't injected in an extension page, reload the page and inject it
 chrome.devtools.inspectedWindow.eval(
-  'devToolsExtension',
+  '[!window.devToolsExtension, chrome.runtime.id]',
   function(result, isException) {
-    if (isException) {
+    if (!isException && result[0] && result[1]) {
       require('./remote');
     }
+    init(result[1]);
   }
 );

--- a/src/browser/extension/devpanel/index.js
+++ b/src/browser/extension/devpanel/index.js
@@ -48,3 +48,20 @@ backgroundPageConnection.postMessage({
   name: 'init',
   tabId: chrome.devtools.inspectedWindow.tabId
 });
+
+// If devToolsExtension wasn't injected, reload the page and inject it
+chrome.devtools.inspectedWindow.eval(
+  'devToolsExtension',
+  function(result, isException) {
+    if (isException) {
+      chrome.devtools.inspectedWindow.reload({
+        injectedScript: 'setTimeout( function () {' +
+        'var s = document.createElement(\'script\');' +
+        's.src = \'' + chrome.extension.getURL('js/content.bundle.js') + '\';' +
+        's.onload = function() { this.parentNode.removeChild(this); };' +
+        'document.documentElement.appendChild(s);' +
+        '}, 0);'
+      });
+    }
+  }
+);

--- a/src/browser/extension/devpanel/index.js
+++ b/src/browser/extension/devpanel/index.js
@@ -5,9 +5,14 @@ import DevTools from '../../../app/containers/DevTools';
 import createDevStore from '../../../app/store/createDevStore';
 
 const store = createDevStore((action) => {
-  chrome.devtools.inspectedWindow.eval('dispatch(' + JSON.stringify(action) + ')', {
-    useContentScriptContext: true
-  });
+  chrome.devtools.inspectedWindow.eval(
+    'window.postMessage({' +
+    'type: \'ACTION\',' +
+    'payload: ' + JSON.stringify(action) + ',' +
+    'source: \'redux-cs\'' +
+    '}, \'*\');',
+    { useContentScriptContext: false }
+  );
 });
 
 let rendered = false;

--- a/src/browser/extension/devpanel/remote.js
+++ b/src/browser/extension/devpanel/remote.js
@@ -1,5 +1,6 @@
 chrome.devtools.inspectedWindow.reload({
   injectedScript: 'setTimeout( function () {' +
+  'window.devToolsExtensionID = \'' + chrome.runtime.id + '\';' +
   'var s = document.createElement(\'script\');' +
   's.src = \'' + chrome.extension.getURL('js/content.bundle.js') + '\';' +
   's.onload = function() { this.parentNode.removeChild(this); };' +

--- a/src/browser/extension/devpanel/remote.js
+++ b/src/browser/extension/devpanel/remote.js
@@ -1,0 +1,8 @@
+chrome.devtools.inspectedWindow.reload({
+  injectedScript: 'setTimeout( function () {' +
+  'var s = document.createElement(\'script\');' +
+  's.src = \'' + chrome.extension.getURL('js/content.bundle.js') + '\';' +
+  's.onload = function() { this.parentNode.removeChild(this); };' +
+  'document.documentElement.appendChild(s);' +
+  '}, 0);'
+});

--- a/src/browser/extension/devpanel/remote.js
+++ b/src/browser/extension/devpanel/remote.js
@@ -1,9 +1,0 @@
-chrome.devtools.inspectedWindow.reload({
-  injectedScript: 'setTimeout( function () {' +
-  'window.devToolsExtensionID = \'' + chrome.runtime.id + '\';' +
-  'var s = document.createElement(\'script\');' +
-  's.src = \'' + chrome.extension.getURL('js/content.bundle.js') + '\';' +
-  's.onload = function() { this.parentNode.removeChild(this); };' +
-  'document.documentElement.appendChild(s);' +
-  '}, 0);'
-});

--- a/src/browser/extension/inject/contentScript.js
+++ b/src/browser/extension/inject/contentScript.js
@@ -48,11 +48,12 @@ if (chrome.runtime.onMessage) {
   });
 }
 
-window.addEventListener('beforeunload', function() {
-  sendMessage({
-    type: 'PAGE_UNLOADED'
-  });
-});
+if (typeof window.onbeforeunload !== 'undefined') {
+  // Prevent adding beforeunload listener for Chrome apps
+  window.onbeforeunload = function() {
+    sendMessage({ type: 'PAGE_UNLOADED' });
+  };
+}
 
 // Detect when the tab is reactivated
 document.addEventListener('visibilitychange', function() {

--- a/src/browser/extension/inject/contentScript.js
+++ b/src/browser/extension/inject/contentScript.js
@@ -8,16 +8,14 @@ const sendMessage = (
     : chrome.runtime.sendMessage
 );
 
-let s = document.createElement('script');
-s.src = (
-  window.devToolsExtensionID ?
-    'chrome-extension://' + window.devToolsExtensionID + '/js/page.bundle.js'
-    : chrome.extension.getURL('js/page.bundle.js')
-);
-s.onload = function() {
-  this.parentNode.removeChild(this);
-};
-(document.head || document.documentElement).appendChild(s);
+if (!window.devToolsExtensionID) {
+  let s = document.createElement('script');
+  s.src = chrome.extension.getURL('js/page.bundle.js');
+  s.onload = function() {
+    this.parentNode.removeChild(this);
+  };
+  (document.head || document.documentElement).appendChild(s);
+}
 
 function parseJSON(data) {
   try {

--- a/src/browser/extension/inject/contentScript.js
+++ b/src/browser/extension/inject/contentScript.js
@@ -1,4 +1,3 @@
-import { ACTION, UPDATE } from '../../../app/constants/ActionTypes';
 let payload;
 
 const sendMessage = (
@@ -38,27 +37,18 @@ window.addEventListener('message', function(event) {
   sendMessage(message);
 });
 
-// Send actions to the page
-window.dispatch = function(action) {
-  window.postMessage({
-    type: ACTION,
-    payload: action,
-    source: 'redux-cs'
-  }, '*');
-};
-
-// Ask for updates from the page
-window.update = function() {
-  window.postMessage({
-    type: UPDATE,
-    source: 'redux-cs'
-  }, '*');
-};
-
 // Request from the background script to send actions to the page
-chrome.runtime.onMessage.addListener((message) => {
-  if (message.action) window.dispatch(message.action);
-});
+if (chrome.runtime.onMessage) {
+  chrome.runtime.onMessage.addListener((message) => {
+    if (message.action) {
+      window.postMessage({
+        type: 'ACTION',
+        payload: message.action,
+        source: 'redux-cs'
+      }, '*');
+    }
+  });
+}
 
 window.addEventListener('beforeunload', function() {
   sendMessage({

--- a/src/browser/extension/inject/index.js
+++ b/src/browser/extension/inject/index.js
@@ -1,0 +1,7 @@
+// Include this script in Chrome apps and extensions for remote debugging
+// <script src="chrome-extension://lmhkpmbekcpmknklioeibfkpmmfibljd/js/inject.bundle.js"></script>
+
+window.devToolsExtensionID = 'lmhkpmbekcpmknklioeibfkpmmfibljd';
+
+require('./contentScript');
+require('./pageScript');

--- a/src/browser/extension/manifest.json
+++ b/src/browser/extension/manifest.json
@@ -28,8 +28,7 @@
   "devtools_page": "devtools.html",
   "web_accessible_resources": ["js/page.bundle.js", "js/content.bundle.js"],
   "externally_connectable": {
-    "ids": ["*"],
-    "matches": ["http://localhost:*/*", "https://localhost:*/*", "http://0.0.0.0:*/*", "https://0.0.0.0:*/*", "http://*.github.io/*", "https://*.github.io/*"]
+    "ids": ["*"]
   },
   "permissions": [ "contextMenus", "tabs", "storage", "<all_urls>" ],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'; style-src * 'unsafe-inline'; img-src 'self' data:;",

--- a/src/browser/extension/manifest.json
+++ b/src/browser/extension/manifest.json
@@ -26,7 +26,11 @@
     }
   ],
   "devtools_page": "devtools.html",
-  "web_accessible_resources": ["js/page.bundle.js"],
+  "web_accessible_resources": ["js/page.bundle.js", "js/content.bundle.js"],
+  "externally_connectable": {
+    "ids": ["*"],
+    "matches": ["http://localhost:*/*", "https://localhost:*/*", "http://0.0.0.0:*/*", "https://0.0.0.0:*/*", "http://*.github.io/*", "https://*.github.io/*"]
+  },
   "permissions": [ "contextMenus", "tabs", "storage", "<all_urls>" ],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'; style-src * 'unsafe-inline'; img-src 'self' data:;",
   "update_url": "https://clients2.google.com/service/update2/crx"

--- a/src/browser/extension/manifest.json
+++ b/src/browser/extension/manifest.json
@@ -26,11 +26,12 @@
     }
   ],
   "devtools_page": "devtools.html",
-  "web_accessible_resources": ["js/page.bundle.js", "js/content.bundle.js"],
+  "web_accessible_resources": ["js/page.bundle.js", "js/inject.bundle.js"],
   "externally_connectable": {
     "ids": ["*"]
   },
   "permissions": [ "contextMenus", "tabs", "storage", "<all_urls>" ],
   "content_security_policy": "script-src 'self' 'unsafe-eval'; object-src 'self'; style-src * 'unsafe-inline'; img-src 'self' data:;",
-  "update_url": "https://clients2.google.com/service/update2/crx"
+  "update_url": "https://clients2.google.com/service/update2/crx",
+  "key": "MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEAsdJEPwY92xUACA9CcDBDBmbdbp8Ap3cKQ0DJTUuVQvqb4FQAv8RtKY3iUjGvdwuAcSJQIZwHXcP2aNDH3TiFik/NhRK2GRW8X3OZyTdkuDueABGP2KEX8q1WQDgjX/rPIinGYztUrvoICw/UerMPwNW62jwGoVU3YhAGf+15CgX2Y6a4tppnf/+1mPedKPidh0RsM+aJY98rX+r1SPAHPcGzMjocLkqcT75DZBXer8VQN14tOOzRCd6T6oy7qm7eWru8lJwcY66qMQvhk0osqEod2G3nA7aTWpmqPFS66VEiecP9PgZlp8gQdgZ3dFhA62exydlD55JuRhiMIR63yQIDAQAB"
 }

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -10,7 +10,8 @@ export default {
     devpanel: [ extpath + 'devpanel/index' ],
     devtools: [ extpath + 'devtools/index' ],
     content: [ extpath + 'inject/contentScript' ],
-    page: [ extpath + 'inject/pageScript' ]
+    page: [ extpath + 'inject/pageScript' ],
+    inject: [ extpath + 'inject/index' ]
   },
   output: {
     filename: '[name].bundle.js',


### PR DESCRIPTION
Added support for external messaging, so it is possible to use devtools for any chrome-based application.

Unlike web apps, Chrome extension doesn't inject anything in other chrome extensions or in chrome / electron / nw.js apps, so you have to do it by yourself to allow debugging. Just add:
```
<script src="chrome-extension://lmhkpmbekcpmknklioeibfkpmmfibljd/js/inject.bundle.js"></script>
```