### PR TITLE
Allow DevTools to access the frames

### DIFF
--- a/src/browser/extension/manifest.json
+++ b/src/browser/extension/manifest.json
@@ -56,7 +56,8 @@
       "matches": ["<all_urls>"],
       "exclude_globs": [ "https://www.google*" ],
       "js": ["js/content.bundle.js", "js/pagewrap.bundle.js"],
-      "run_at": "document_start"
+      "run_at": "document_start",
+      "all_frames": true
     }
   ],
   "devtools_page": "devtools.html",


### PR DESCRIPTION
Adds the "all_frames" option to the manifest.json to allow DevTools to access iframes that might hold the Store instead of the main page.

Solves: https://github.com/zalmoxisus/redux-devtools-extension/issues/50