### PR TITLE
Cleanup hash before getting the session name

### DIFF
--- a/src/app/store/configureStore.js
+++ b/src/app/store/configureStore.js
@@ -10,6 +10,7 @@ export default function configureStore(next, subscriber = () => ({})) {
   )(next);
 }
 function getPersistSession() {
-  const matches = window.location.href.match(/[?&]debug_session=([^&]+)\b/);
+  const pageHref = window.location.href.substr(0, window.location.href.indexOf('#'))
+  const matches = pageHref.match(/[?&]debug_session=([^&]+)\b/);
   return (matches && matches.length > 0)? matches[1] : null;
 }


### PR DESCRIPTION
Persisting state does not work when using hash navigation.
Generated keys look like this : redux-dev-session-mysession#/56c464fd98a6fa921045d8ba/login?_k=l5l5jd

This fixes the problem by removing the hash before getting the session name.