### PR TITLE
add deserialize callbacks for persistState

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,10 @@ If you do not know what [Redux DevTools](https://github.com/gaearon/redux-devtoo
 `window.devToolsExtension([config])`
 - **config** arguments (optional)
   - **name** (*string*) - the instance name to be showed on the monitor page. Default value is `document.title`.
+  - **deserializeState(state): transformedState** (*function*) - optional transformation of state deserialized from debug session (useful if state is not plain object. Example: immutable-js state)
+    - state, transformedState - Redux state objects
+  - **deserializeAction(action): transformedAction** (*function*) - optional transformation of actions deserialized from debug session (useful if actions are not plain object. Example: immutable-js action payload)
+    - action, transformedAction - Redux action objects
 
 ## Examples
 Open these urls to test the extension:

--- a/src/app/store/configureStore.js
+++ b/src/app/store/configureStore.js
@@ -1,11 +1,14 @@
 import { compose } from 'redux';
 import { persistState, instrument } from 'redux-devtools';
 
-export default function configureStore(next, subscriber = () => ({})) {
+export default function configureStore(next, subscriber = () => ({}), options = {}) {
+  const { deserializeState, deserializeAction } = options;
   return compose(
     instrument(subscriber),
     persistState(
-      getPersistSession()
+      getPersistSession(),
+      deserializeState,
+      deserializeAction
     )
   )(next);
 }

--- a/src/browser/extension/inject/pageScript.js
+++ b/src/browser/extension/inject/pageScript.js
@@ -140,7 +140,11 @@ window.devToolsExtension = function(config = {}) {
     return (reducer, initialState, enhancer) => {
       if (!isAllowed(window.devToolsOptions)) return next(reducer, initialState, enhancer);
 
-      store = configureStore(next, monitorReducer)(reducer, initialState, enhancer);
+      const { deserializeState, deserializeAction } = config;
+      store = configureStore(next, monitorReducer, {
+        deserializeState, 
+        deserializeAction
+      })(reducer, initialState, enhancer);
       init();
       store.subscribe(() => { handleChange(store.getState(), store.liftedStore.getState()); });
       return store;


### PR DESCRIPTION
Adds desirialize callbacks ([https://github.com/gaearon/redux-devtools/blob/ccb3f2f07040561b8ae4b307767f745be3b9cc96/src/persistState.js#L4](https://github.com/gaearon/redux-devtools/blob/ccb3f2f07040561b8ae4b307767f745be3b9cc96/src/persistState.js#L4)) for persistState as config arguments.
If you approve it, I can update config arguments part in README