### PR TITLE
The extension shouldn't affect the performance when no monitors are opened

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,7 +53,7 @@
     "webpack": "^1.12.2"
   },
   "dependencies": {
-    "crossmessaging": "^0.2.0",
+    "crossmessaging": "^0.2.1",
     "jsan": "^3.1.1",
     "react": "^0.14.6",
     "react-dom": "^0.14.6",

--- a/src/browser/extension/background/contextMenus.js
+++ b/src/browser/extension/background/contextMenus.js
@@ -7,8 +7,6 @@ const menus = [
   { id: 'devtools-panel', title: 'Open in a chrome panel (enable in Chrome settings)' },
   { id: 'devtools-remote', title: 'Open Remote DevTools' }
 ];
-let pageUrl;
-let pageTab;
 
 let shortcuts = {};
 chrome.commands.getAll(commands => {
@@ -17,24 +15,12 @@ chrome.commands.getAll(commands => {
   });
 });
 
-export default function createMenu(forUrl, tabId) {
-  if (typeof tabId !== 'number') return; // It is an extension's background page
-  chrome.pageAction.show(tabId);
-  if (tabId === pageTab) return;
-
-  let url = forUrl;
-  let hash = forUrl.indexOf('#');
-  if (hash !== -1) url = forUrl.substr(0, hash);
-  if (pageUrl === url) return;
-  pageUrl = url; pageTab = tabId;
-  chrome.contextMenus.removeAll();
-
+export default function createMenu() {
   menus.forEach(({ id, title }) => {
     chrome.contextMenus.create({
       id: id,
       title: title + (shortcuts[id] ? ' (' + shortcuts[id] + ')' : ''),
       contexts: ['all'],
-      documentUrlPatterns: [url],
       onclick: () => { openDevToolsWindow(id); }
     });
   });

--- a/src/browser/extension/background/index.js
+++ b/src/browser/extension/background/index.js
@@ -1,6 +1,7 @@
 import createDevStore from 'remotedev-app/lib/store/createDevStore';
 import openDevToolsWindow from './openWindow';
 import { toContentScript } from './messaging';
+import createMenu from './contextMenus';
 
 const store = createDevStore((action) => {
   toContentScript(action);
@@ -12,3 +13,4 @@ window.store.liftedStore.instances = {};
 chrome.commands.onCommand.addListener(shortcut => {
   openDevToolsWindow(shortcut);
 });
+setTimeout(createMenu, 0);

--- a/src/browser/extension/background/messaging.js
+++ b/src/browser/extension/background/messaging.js
@@ -1,7 +1,6 @@
 import { onConnect, onMessage, sendToTab } from 'crossmessaging';
 import updateState from 'remotedev-app/lib/store/updateState';
 import syncOptions from '../options/syncOptions';
-import createMenu from './contextMenus';
 import openDevToolsWindow from './openWindow';
 let panelConnections = {};
 let tabConnections = {};

--- a/src/browser/extension/background/messaging.js
+++ b/src/browser/extension/background/messaging.js
@@ -16,8 +16,12 @@ function initPanel(msg, port) {
   if (msg.tabId !== store.id) return naMessage;
 }
 
+function getId(port) {
+  return port.sender.tab ? port.sender.tab.id : port.sender.id;
+}
+
 function initInstance(msg, port) {
-  const id = port.sender.tab.id;
+  const id = getId(port);
   tabConnections[id] = port;
   store.liftedStore.instances[id] = msg.instance;
   store.id = id;
@@ -26,8 +30,8 @@ function initInstance(msg, port) {
 }
 
 function disconnect(port) {
-  if (!port.sender.tab) return;
-  const id = port.sender.tab.id;
+  if (!port.sender.tab && port.id === chrome.runtime.id) return;
+  const id = getId(port);
   delete tabConnections[id];
   if (panelConnections[id]) panelConnections[id].postMessage(naMessage);
   if (window.store.liftedStore.instances[id]) {

--- a/src/browser/extension/devpanel/index.js
+++ b/src/browser/extension/devpanel/index.js
@@ -56,7 +56,7 @@ function init(id) {
     'source: \'redux-cs\'' +
     '}, \'*\');'
   );
-  backgroundPageConnection.postMessage({ name: 'init', tabId: id });
+  backgroundPageConnection.postMessage({ name: 'INIT_PANEL', tabId: id });
 }
 
 if (chrome.devtools.inspectedWindow.tabId) {

--- a/src/browser/extension/inject/contentScript.js
+++ b/src/browser/extension/inject/contentScript.js
@@ -21,9 +21,9 @@ function connect(instance) {
         payload: message.action,
         source: 'redux-cs'
       }, '*');
-    } else if (message.type === 'START') {
+    } else {
       window.postMessage({
-        type: 'START',
+        type: message.type,
         source: 'redux-cs'
       }, '*');
     }

--- a/src/browser/extension/inject/contentScript.js
+++ b/src/browser/extension/inject/contentScript.js
@@ -1,27 +1,33 @@
-import { onMessage, sendToBg } from 'crossmessaging';
 import { getOptionsFromBg, isAllowed } from '../options/syncOptions';
+let bg;
 let payload;
-let sendMessage;
 
 if (!window.devToolsOptions) getOptionsFromBg();
 
-// Relay background script massages to the page script
-onMessage((message) => {
-  if (message.action) {
-    window.postMessage({
-      type: 'DISPATCH',
-      payload: message.action,
-      source: 'redux-cs'
-    }, '*');
+function connect(instance) {
+  // Connect to the background script
+  if (window.devToolsExtensionID) {
+    bg = chrome.runtime.connect(window.devToolsExtensionID);
+  } else {
+    bg = chrome.runtime.connect();
   }
-});
+  bg.postMessage({name: 'INIT_INSTANCE', instance});
 
-if (window.devToolsExtensionID) { // Send external messages
-  sendMessage = function(message) {
-    chrome.runtime.sendMessage(window.devToolsExtensionID, message);
-  };
-} else {
-  sendMessage = sendToBg;
+  // Relay background script massages to the page script
+  bg.onMessage.addListener((message) => {
+    if (message.action) {
+      window.postMessage({
+        type: 'DISPATCH',
+        payload: message.action,
+        source: 'redux-cs'
+      }, '*');
+    } else if (message.type === 'START') {
+      window.postMessage({
+        type: 'START',
+        source: 'redux-cs'
+      }, '*');
+    }
+  });
 }
 
 // Resend messages from the page to the background script
@@ -32,7 +38,9 @@ window.addEventListener('message', function(event) {
   if (message.source !== 'redux-page') return;
   if (message.payload) payload = message.payload;
   try {
-    sendMessage(message);
+    if (message.type === 'INIT_INSTANCE') {
+      connect(message.name);
+    } else bg.postMessage({ name: 'RELAY', message });
   } catch (err) {
     if (process.env.NODE_ENV !== 'production') console.error('Failed to send message', err);
   }
@@ -42,6 +50,6 @@ if (typeof window.onbeforeunload !== 'undefined') {
   // Prevent adding beforeunload listener for Chrome apps
   window.onbeforeunload = function() {
     if (!isAllowed()) return;
-    sendMessage({ type: 'PAGE_UNLOADED' });
+    bg.postMessage({ type: 'PAGE_UNLOADED' });
   };
 }

--- a/src/browser/extension/inject/pageScript.js
+++ b/src/browser/extension/inject/pageScript.js
@@ -10,6 +10,7 @@ window.devToolsExtension = function(config = {}) {
   let shouldInit = true;
   let lastAction;
   let errorOccurred = false;
+  let isMonitored = false;
 
   function stringify(obj) {
     return jsan.stringify(obj, function(key, value) {
@@ -65,6 +66,11 @@ window.devToolsExtension = function(config = {}) {
       store.liftedStore.dispatch(message.payload);
     } else if (message.type === 'UPDATE') {
       relay('STATE', store.liftedStore.getState());
+    } else if (message.type === 'START') {
+      isMonitored = true;
+      relay('STATE', store.liftedStore.getState());
+    } else if (message.type === 'STOP') {
+      isMonitored = false;
     }
   }
 
@@ -110,7 +116,7 @@ window.devToolsExtension = function(config = {}) {
 
     // Detect when the tab is reactivated
     document.addEventListener('visibilitychange', function() {
-      if (document.visibilityState === 'visible') {
+      if (document.visibilityState === 'visible' && isMonitored) {
         shouldInit = true;
         relay('STATE', store.liftedStore.getState());
       }
@@ -118,6 +124,7 @@ window.devToolsExtension = function(config = {}) {
   }
 
   function monitorReducer(state = {}, action) {
+    if (!isMonitored) return state;
     lastAction = action.type;
     if (lastAction === '@@redux/INIT' && store.liftedStore) {
       // Send new lifted state on hot-reloading
@@ -129,6 +136,7 @@ window.devToolsExtension = function(config = {}) {
   }
 
   function handleChange(state, liftedState) {
+    if (!isMonitored) return;
     const nextActionId = liftedState.nextActionId;
     const liftedAction = liftedState.actionsById[nextActionId - 1];
     const action = liftedAction.action;

--- a/src/browser/extension/inject/pageScript.js
+++ b/src/browser/extension/inject/pageScript.js
@@ -20,7 +20,7 @@ window.devToolsExtension = function(config = {}) {
   }
 
   function relaySerialized(message) {
-    message.payload = stringify(message.payload);
+    if (message.payload) message.payload = stringify(message.payload);
     if (message.action !== '') message.action = stringify(message.action);
     window.postMessage(message, '*');
   }
@@ -103,7 +103,7 @@ window.devToolsExtension = function(config = {}) {
 
   function init() {
     window.addEventListener('message', onMessage, false);
-    relay('STATE', store.liftedStore.getState());
+    relay('INIT_INSTANCE');
     notifyErrors(() => {
       errorOccurred = true;
       const state = store.liftedStore.getState();

--- a/src/browser/extension/window/index.js
+++ b/src/browser/extension/window/index.js
@@ -2,9 +2,12 @@ import React from 'react';
 import { render } from 'react-dom';
 import DevTools from '../../../app/containers/DevTools';
 
-chrome.runtime.getBackgroundPage( background => {
-  render(
-    <DevTools store={background.store} />,
-    document.getElementById('root')
-  );
+chrome.runtime.getBackgroundPage(background => {
+  background.getStore((store, unsubscribe) => {
+    render(
+      <DevTools store={store} />,
+      document.getElementById('root')
+    );
+    addEventListener('unload', unsubscribe, true);
+  });
 });


### PR DESCRIPTION
Due to Chrome restrictions, the extension is not allowed to communicate with the app's script directly, so we relay every change to the background script. By introducing new features in #60, the serialization for every change [becomes slower](https://github.com/zalmoxisus/redux-devtools-extension/issues/67#issuecomment-191364884), which is [a problem when having a lot of data in states](https://twitter.com/tjholowaychuk/status/707283606763229184).

We want the extension not to process the changes while it is not required as most of the time we don't monitor the changes.

The problem is to support simultaneous instances in this scenario, so we need to change the way of messaging by using long-lived connections.