### PR TITLE
Fix "uncaught TypeError: reducer is not a function" in examples

### DIFF
--- a/examples/counter/store/configureStore.js
+++ b/examples/counter/store/configureStore.js
@@ -12,7 +12,7 @@ export default function configureStore(initialState) {
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('../reducers', () => {
-      const nextReducer = require('../reducers');
+      const nextReducer = require('../reducers').default;
       store.replaceReducer(nextReducer);
     });
   }

--- a/examples/router/store/configureStore.js
+++ b/examples/router/store/configureStore.js
@@ -15,7 +15,7 @@ export default function configureStore(initialState) {
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('../reducers', () => {
-      const nextReducer = require('../reducers');
+      const nextReducer = require('../reducers').default;
       store.replaceReducer(nextReducer);
     });
   }

--- a/examples/todomvc/store/configureStore.js
+++ b/examples/todomvc/store/configureStore.js
@@ -9,7 +9,7 @@ export default function configureStore(initialState) {
   if (module.hot) {
     // Enable Webpack hot module replacement for reducers
     module.hot.accept('../reducers', () => {
-      const nextReducer = require('../reducers');
+      const nextReducer = require('../reducers').default;
       store.replaceReducer(nextReducer);
     });
   }


### PR DESCRIPTION
Guarantee reducer import by explicitly setting `.default`
gaearon/redux-devtools#233