### PR TITLE
Add missing `crossmessaging` dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "webpack": "^1.12.2"
   },
   "dependencies": {
+    "crossmessaging": "^0.2.1",
     "jsan": "^3.1.1",
     "lodash": "^4.2.0",
     "react": "^15.0.2",


### PR DESCRIPTION
Build is failing on `master`. It looks like it’s missing a dependency, [`crossmessaging`](https://github.com/zalmoxisus/crossmessaging).

```
ERROR in ./src/app/containers/App.js
Module not found: Error: Cannot resolve module 'crossmessaging' in redux-devtools-extension/src/app/containers
 @ ./src/app/containers/App.js 16:22-47
```