### PR TITLE
Support Electron DevTools extension

### DIFF
--- a/src/app/containers/App.js
+++ b/src/app/containers/App.js
@@ -67,6 +67,7 @@ export default class App extends Component {
     const { store } = this.props;
     const instances = store.instances;
     const { instance, monitor } = this.state;
+    const onElectron = navigator.userAgent.indexOf('Electron') !== -1;
     return (
       <div style={styles.container}>
           <div style={styles.buttonBar}>
@@ -86,19 +87,19 @@ export default class App extends Component {
           />
         }
         <div style={styles.buttonBar}>
-          {monitorPosition !== 'left' &&
+          {!onElectron && monitorPosition !== 'left' &&
             <Button
               Icon={LeftIcon}
               onClick={() => { this.openWindow('left'); }}
             />
           }
-          {monitorPosition !== 'right' &&
+          {!onElectron && monitorPosition !== 'right' &&
             <Button
               Icon={RightIcon}
               onClick={() => { this.openWindow('right'); }}
             />
           }
-          {monitorPosition !== 'bottom' &&
+          {!onElectron && monitorPosition !== 'bottom' &&
             <Button
               Icon={BottomIcon}
               onClick={() => { this.openWindow('bottom'); }}
@@ -110,10 +111,12 @@ export default class App extends Component {
           <SliderButton isOpen={this.state.sliderIsOpen} onClick={this.toggleSlider} />
           <ImportButton importState={store.liftedStore.importState} />
           <ExportButton exportState={store.liftedStore.getState} />
-          <Button
-            Icon={RemoteIcon}
-            onClick={() => { this.openWindow('remote'); }}
-          >Remote</Button>
+          {!onElectron &&
+            <Button
+              Icon={RemoteIcon}
+              onClick={() => { this.openWindow('remote'); }}
+            >Remote</Button>
+          }
           {chrome.runtime.openOptionsPage &&
             <Button
               Icon={SettingsIcon}

--- a/src/browser/extension/background/messaging.js
+++ b/src/browser/extension/background/messaging.js
@@ -40,7 +40,8 @@ function messaging(request, sender, sendResponse) {
       return true;
     }
     if (request.type === 'ERROR') {
-      chrome.notifications.create('app-error', {
+      // Electron: Not supported some chrome.* API
+      chrome.notifications && chrome.notifications.create('app-error', {
         type: 'basic',
         title: 'An error occurred in the app',
         message: request.message,
@@ -152,14 +153,19 @@ function onConnect(port) {
 }
 
 chrome.runtime.onConnect.addListener(onConnect);
-chrome.runtime.onConnectExternal.addListener(onConnect);
 chrome.runtime.onMessage.addListener(messaging);
-chrome.runtime.onMessageExternal.addListener(messaging);
 
-chrome.notifications.onClicked.addListener(id => {
-  chrome.notifications.clear(id);
-  if (id === 'redux-error') openDevToolsWindow('devtools-right');
-});
+// Electron: Not supported some chrome.* API
+chrome.runtime.onConnectExternal &&
+  chrome.runtime.onConnectExternal.addListener(onConnect);
+chrome.runtime.onMessageExternal && 
+  chrome.runtime.onMessageExternal.addListener(messaging);
+
+chrome.notifications &&
+  chrome.notifications.onClicked.addListener(id => {
+    chrome.notifications.clear(id);
+    if (id === 'redux-error') openDevToolsWindow('devtools-right');
+  });
 
 export function toContentScript(type, action, id, state) {
   const message = { type, action, state, id };


### PR DESCRIPTION
Related to #135, it's only for devpanel.

#### Screenshot

![2016-06-21 9 00 17](https://cloud.githubusercontent.com/assets/3001525/16214808/a53ca016-378e-11e6-97ce-3109b308aa1b.png)

Tested with [electron-react-boilerplate](https://github.com/chentsulin/electron-react-boilerplate)

Known some chrome.* API Electron not supported:

* chrome.notifications
* chrome.runtime.onConnectExternal
* chrome.runtime.onMessageExternal