### PR TITLE
Fix production copy path in gulpfile

### DIFF
--- a/gulpfile.babel.js
+++ b/gulpfile.babel.js
@@ -89,7 +89,7 @@ gulp.task('copy:build:extension', () => {
   gulp.src('./src/browser/extension/manifest.json')
     .pipe(rename('manifest.json'))
     .pipe(gulp.dest('./build/extension'));
-  copy('./dev');
+  copy('./build/extension');
 });
 
 gulp.task('copy:build:firefox', ['build:extension'], () => {
@@ -98,7 +98,7 @@ gulp.task('copy:build:firefox', ['build:extension'], () => {
       gulp.src('./src/browser/firefox/manifest.json')
         .pipe(gulp.dest('./build/firefox'));
     });
-  copy('./dev');
+  copy('./build/extension');
 });
 
 /*


### PR DESCRIPTION
Currently it has `ERR_FILE_NOT_FOUND` errors, it looks css files not included in v2.2.0.