### PR TITLE
Fix eslint errors

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,6 +18,7 @@
     "quotes": [ 1, "single" ],
     "comma-style": [ 2, "last" ],
     "eol-last": 0,
+    "no-use-before-define": [0, "nofunc"],
     "no-unused-vars": 0,
     "no-console": 0,
     "func-names": 0,

--- a/package.json
+++ b/package.json
@@ -4,6 +4,9 @@
   "description": "DevTools extension for Redux",
   "scripts": {
     "start": "gulp",
+    "prebuild:extension": "npm run lint",
+    "prebuild:firefox": "npm run lint",
+    "prebuild:examples": "npm run lint",
     "build:extension": "BABEL_ENV=production gulp build:extension",
     "build:firefox": "BABEL_ENV=production gulp build:firefox",
     "build:examples": "babel-node examples/buildAll.js",

--- a/src/app/containers/App.js
+++ b/src/app/containers/App.js
@@ -18,7 +18,7 @@ import RemoteIcon from 'react-icons/lib/go/radio-tower';
 
 const monitorPosition = location.hash;
 
-let monitor;
+let initialMonitor;
 let selectedTemplate;
 let testTemplates;
 
@@ -29,12 +29,12 @@ if (chrome.storage.local) {
     'test-templates': null,
     'test-templates-sel': null
   }, options => {
-    monitor = options['monitor' + monitorPosition];
+    initialMonitor = options['monitor' + monitorPosition];
     selectedTemplate = options['test-templates-sel'];
     testTemplates = options['test-templates'];
   });
 } else {
-  monitor = localStorage.getItem('monitor' + monitorPosition]) || 'InspectorMonitor';
+  initialMonitor = localStorage.getItem('monitor' + monitorPosition) || 'InspectorMonitor';
   selectedTemplate = localStorage.getItem('test-templates-sel');
   testTemplates = localStorage.getItem('test-templates');
 }
@@ -47,7 +47,7 @@ export default class App extends Component {
   };
 
   state = {
-    monitor,
+    monitor: initialMonitor,
     instance: 'auto',
     dispatcherIsOpen: false,
     sliderIsOpen: false

--- a/src/browser/extension/background/messaging.js
+++ b/src/browser/extension/background/messaging.js
@@ -4,7 +4,7 @@ import openDevToolsWindow from './openWindow';
 let panelConnections = {};
 let tabConnections = {};
 let monitorConnections = {};
-let instancesConn = {}
+let instancesConn = {};
 let catchedErrors = {};
 let monitors = 0;
 let isMonitored = false;
@@ -41,13 +41,15 @@ function messaging(request, sender, sendResponse) {
     }
     if (request.type === 'ERROR') {
       // Electron: Not supported some chrome.* API
-      chrome.notifications && chrome.notifications.create('app-error', {
-        type: 'basic',
-        title: 'An error occurred in the app',
-        message: request.message,
-        iconUrl: 'img/logo/48x48.png',
-        isClickable: false
-      });
+      if (chrome.notifications) {
+        chrome.notifications.create('app-error', {
+          type: 'basic',
+          title: 'An error occurred in the app',
+          message: request.message,
+          iconUrl: 'img/logo/48x48.png',
+          isClickable: false
+        });
+      }
       return true;
     }
 
@@ -156,16 +158,19 @@ chrome.runtime.onConnect.addListener(onConnect);
 chrome.runtime.onMessage.addListener(messaging);
 
 // Electron: Not supported some chrome.* API
-chrome.runtime.onConnectExternal &&
+if (chrome.runtime.onConnectExternal) {
   chrome.runtime.onConnectExternal.addListener(onConnect);
-chrome.runtime.onMessageExternal && 
+}
+if (chrome.runtime.onMessageExternal) {
   chrome.runtime.onMessageExternal.addListener(messaging);
+}
 
-chrome.notifications &&
+if (chrome.notifications) {
   chrome.notifications.onClicked.addListener(id => {
     chrome.notifications.clear(id);
     if (id === 'redux-error') openDevToolsWindow('devtools-right');
   });
+}
 
 export function toContentScript(type, action, id, state) {
   const message = { type, action, state, id };

--- a/src/browser/extension/options/index.js
+++ b/src/browser/extension/options/index.js
@@ -17,7 +17,7 @@ chrome.runtime.getBackgroundPage(background => {
   const isValidRegex = str => {
     let isValid = true;
     try {
-      new RegExp(str);
+      new RegExp(str); // eslint-disable-line no-new
     } catch (e) {
       isValid = false;
     }


### PR DESCRIPTION
This should fix #150 .

However, when I tried to run `npm run compress:extension`, it shows an error:

```
ERROR in ./src/app/containers/App.js
Module not found: Error: Cannot resolve module 'remotedev-app/lib/components/TestGenerator' in ……/redux-devtools-extension/src/app/containers
 @ ./src/app/containers/App.js 56:21-74
```

Other than that it looks good.