### PR TITLE
Update Electron mock

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -3,7 +3,7 @@ environment:
     - nodejs_version: '4'
 
 cache:
-  - node_modules
+  - node_modules -> package.json
 
 install:
   - ps: Install-Product node $env:nodejs_version

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
     "webpack": "^1.12.2"
   },
   "dependencies": {
+    "codemirror": "^5.16.0",
     "jsan": "^3.1.1",
     "lodash": "^4.2.0",
     "react": "^15.1.0",

--- a/src/browser/extension/background/contextMenus.js
+++ b/src/browser/extension/background/contextMenus.js
@@ -25,8 +25,6 @@ export default function createMenu() {
   });
 }
 
-if (chrome.contextMenus) {
-  chrome.contextMenus.onClicked.addListener(({ menuItemId }) => {
-    openDevToolsWindow(menuItemId);
-  });
-}
+chrome.contextMenus.onClicked.addListener(({ menuItemId }) => {
+  openDevToolsWindow(menuItemId);
+});

--- a/src/browser/extension/electronMock.js
+++ b/src/browser/extension/electronMock.js
@@ -24,25 +24,27 @@ if (
 }
 
 if (window.isElectron) {
-  chrome.storage.local = {
-    set(obj, callback) {
-      Object.keys(obj).forEach(key => {
-        localStorage.setItem(key, obj[key]);
-      });
-      if (callback) {
-        callback();
+  if (!chrome.storage.local) {
+    chrome.storage.local = {
+      set(obj, callback) {
+        Object.keys(obj).forEach(key => {
+          localStorage.setItem(key, obj[key]);
+        });
+        if (callback) {
+          callback();
+        }
+      },
+      get(obj, callback) {
+        const result = {};
+        Object.keys(obj).forEach(key => {
+          result[key] = localStorage.getItem(key) || obj[key];
+        });
+        if (callback) {
+          callback(result);
+        }
       }
-    },
-    get(obj, callback) {
-      const result = {};
-      Object.keys(obj).forEach(key => {
-        result[key] = localStorage.getItem(key) || obj[key];
-      });
-      if (callback) {
-        callback(result);
-      }
-    }
-  };
+    };
+  }
   // Avoid error: chrome.runtime.sendMessage is not supported responseCallback
   const originSendMessage = chrome.runtime.sendMessage;
   chrome.runtime.sendMessage = function() {

--- a/src/browser/extension/electronMock.js
+++ b/src/browser/extension/electronMock.js
@@ -21,6 +21,11 @@ if (
     create() {},
     clear() {}
   };
+  chrome.contextMenus = {
+    onClicked: {
+      addListener() {}
+    },
+  };
 }
 
 if (window.isElectron) {

--- a/src/browser/extension/electronMock.js
+++ b/src/browser/extension/electronMock.js
@@ -43,4 +43,15 @@ if (window.isElectron) {
       }
     }
   };
+  // Avoid error: chrome.runtime.sendMessage is not supported responseCallback
+  const originSendMessage = chrome.runtime.sendMessage;
+  chrome.runtime.sendMessage = function() {
+    if (process.env.NODE_ENV === 'development') {
+      return originSendMessage(...arguments);
+    }
+    if (typeof arguments[arguments.length - 1] === 'function') {
+      Array.prototype.pop.call(arguments);
+    }
+    return originSendMessage(...arguments);
+  };
 }

--- a/test/electron/devpanel.spec.js
+++ b/test/electron/devpanel.spec.js
@@ -32,7 +32,8 @@ describe('DevTools panel for Electron', function() {
     expect(await this.driver.getCurrentUrl())
       .toMatch(/chrome-devtools:\/\/devtools\/bundled\/inspector.html/);
 
-    await delay(1000); // wait loading of redux devtools
+    await this.driver.manage().timeouts().pageLoadTimeout(5000);
+
     const id = await this.driver.executeScript(function() {
       const tabs = WebInspector.inspectorView._tabbedPane._tabs;
       const lastPanelId = tabs[tabs.length - 1].id;

--- a/test/electron/devpanel.spec.js
+++ b/test/electron/devpanel.spec.js
@@ -68,4 +68,14 @@ describe('DevTools panel for Electron', function() {
   Object.keys(switchMonitorTests).forEach(description =>
     it(description, switchMonitorTests[description].bind(this))
   );
+
+  it('should be no logs in console of main window', async () => {
+    const handles = await this.driver.getAllWindowHandles();
+    await this.driver.switchTo().window(handles[1]); // Change to main window
+
+    expect(await this.driver.getTitle()).toBe('Electron Test');
+
+    const logs = await this.driver.manage().logs().get(webdriver.logging.Type.BROWSER);
+    expect(logs).toEqual([]);
+  });
 });

--- a/webpack/base.config.js
+++ b/webpack/base.config.js
@@ -12,7 +12,7 @@ const baseConfig = (params) => ({
     remote: [ `${extpath}window/remote` ],
     devpanel: [ electronMock, `${extpath}devpanel/index` ],
     devtools: [ `${extpath}devtools/index` ],
-    content: [ `${extpath}inject/contentScript` ],
+    content: [ electronMock, `${extpath}inject/contentScript` ],
     pagewrap: [ `${extpath}inject/pageScriptWrap` ],
     inject: [ `${extpath}inject/index` ],
     ...params.inputExtra


### PR DESCRIPTION
The `chrome.runtime.sendMessage` is related to https://github.com/chentsulin/electron-react-boilerplate/issues/266.

The `chrome.storage.local` is officially supported on v1.2.6, we can check it exists.