### PR TITLE
Simpler examples for implementation-docs, in accordance with redux-docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,6 +12,7 @@
  - or run it in dev mode with `npm i & npm start` and [load the extension's folder](https://developer.chrome.com/extensions/getstarted#unpacked) `./dev`.
 
 #### 2. Use with [Redux](https://github.com/rackt/redux)
+##### 2.1 Basic store
   
   If you have a basic [store](http://redux.js.org/docs/api/createStore.html) as described in the official [redux-docs](http://redux.js.org/index.html), simply replace:
   ```javascript
@@ -22,7 +23,8 @@
   let store = createStore(reducer, window.devToolsExtension && window.devToolsExtension());
   ```
 
-  For a setup with [middleware and enhancers](http://redux.js.org/docs/api/applyMiddleware.html):
+##### 2.2 Advanced store setup
+  If you setup your store with [middleware and enhancers](http://redux.js.org/docs/api/applyMiddleware.html):
   ```javascript
   import { createStore, applyMiddleware, compose } from 'redux';
   
@@ -37,13 +39,14 @@
     window.devToolsExtension ? window.devToolsExtension() : f => f
   ));
   ```
-  with [initialState](http://redux.js.org/docs/api/createStore.html) but without middleware and enhancers arguments:
+  **Or** with [initialState](http://redux.js.org/docs/api/createStore.html) but without middleware and enhancers arguments:
   ```javascript
   let store = createStore(reducer, initialState, 
     window.devToolsExtension && window.devToolsExtension()
   );
   ```
-  *or for universal (isomorphic) apps*
+
+  **Or** for universal (isomorphic) apps
   ```javascript
     typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ? window.devToolsExtension() : f => f
   ```

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
   ```
 
 ##### 2.2 Advanced store setup
-  If you setup your store with [middleware and enhancers](http://redux.js.org/docs/api/applyMiddleware.html):
+  - If you setup your store with [middleware and enhancers](http://redux.js.org/docs/api/applyMiddleware.html), change this:
   ```javascript
   import { createStore, applyMiddleware, compose } from 'redux';
   
@@ -32,28 +32,31 @@
     applyMiddleware(...middleware)
   ));
   ```
-  *becomes*
+  to this:
   ```javascript
   let store = createStore(reducer, initialState, compose(
     applyMiddleware(...middleware),
     window.devToolsExtension ? window.devToolsExtension() : f => f
   ));
   ```
-  **Or** with [initialState](http://redux.js.org/docs/api/createStore.html) but without middleware and enhancers arguments:
+  - Or with [initialState](http://redux.js.org/docs/api/createStore.html) but without middleware and enhancers arguments:
   ```javascript
   let store = createStore(reducer, initialState, 
     window.devToolsExtension && window.devToolsExtension()
   );
   ```
 
-  **Or** for universal (isomorphic) apps
+  - Or for universal (isomorphic) apps
   ```javascript
     typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ? window.devToolsExtension() : f => f
   ```
-  You can use it together with vanilla Redux DevTools as a fallback, but not both simultaneously:
+  
+#### With Redux DevTools
+  You can use this extension together with vanilla [Redux DevTools](https://github.com/gaearon/redux-devtools) as a fallback, but not both simultaneously:
   ```js
   window.devToolsExtension ? window.devToolsExtension() : DevTools.instrument()
   ```
+  
   [Make sure not to render DevTools when using the extension](https://github.com/zalmoxisus/redux-devtools-extension/issues/57) or you'll probably want to render the monitor from vanilla DevTools as follows: 
   ```js
   { !window.devToolsExtension ? <DevTools /> : null }

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@
     window.devToolsExtension && window.devToolsExtension()
   );
   ```
-  
+  Note: passing enhancer as last argument requires redux@>=3.1.0. For older versions apply it like [here](https://github.com/zalmoxisus/redux-devtools-extension/blob/v0.4.2/examples/todomvc/store/configureStore.js) or [here](https://github.com/zalmoxisus/redux-devtools-extension/blob/v0.4.2/examples/counter/store/configureStore.js#L7-L12).
 ##### 2.3 Together with Redux DevTools
   You can use this extension together with vanilla [Redux DevTools](https://github.com/gaearon/redux-devtools) as a fallback, but not both simultaneously:
   ```js
@@ -58,7 +58,7 @@
   { !window.devToolsExtension ? <DevTools /> : null }
   ```
   
-  Note: passing enhancer as last argument requires redux@>=3.1.0. For older versions apply it like [here](https://github.com/zalmoxisus/redux-devtools-extension/blob/v0.4.2/examples/todomvc/store/configureStore.js) or [here](https://github.com/zalmoxisus/redux-devtools-extension/blob/v0.4.2/examples/counter/store/configureStore.js#L7-L12).
+  
 #### 3. Use with universal (isomorphic) apps
 ```javascript
   typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ? window.devToolsExtension() : f => f

--- a/README.md
+++ b/README.md
@@ -12,35 +12,36 @@
  - or run it in dev mode with `npm i & npm start` and [load the extension's folder](https://developer.chrome.com/extensions/getstarted#unpacked) `./dev`.
 
 #### 2. Use with [Redux](https://github.com/rackt/redux)
-  Just update your [configureStore](https://github.com/zalmoxisus/redux-devtools-extension/commit/9c631ef66f53e51f34b55f4642bd9ff2cbc7a992):
+  
+  If you have a basic [store](http://redux.js.org/docs/api/createStore.html) as described in the official [redux-docs](http://redux.js.org/index.html), simply replace:
+  ```javascript
+  let store = createStore(reducer);
+  ```
+  with
+  ```javascript
+  let store = createStore(reducer, window.devToolsExtension && window.devToolsExtension());
+  ```
+
+  For a setup with [middleware and enhancers](http://redux.js.org/docs/api/applyMiddleware.html):
   ```javascript
   import { createStore, applyMiddleware, compose } from 'redux';
   
-  export default function configureStore(initialState) {
-    const store = createStore(reducer, initialState, compose(
-      applyMiddleware(...middleware)
-    ));
-    return store;
-  }
+  let store = createStore(reducer, initialState, compose(
+    applyMiddleware(...middleware)
+  ));
   ```
   *becomes*
   ```javascript
-  export default function configureStore(initialState) {
-    const store = createStore(reducer, initialState, compose(
-      applyMiddleware(...middleware),
-      window.devToolsExtension ? window.devToolsExtension() : f => f
-    ));
-    return store;
-  }
+  let store = createStore(reducer, initialState, compose(
+    applyMiddleware(...middleware),
+    window.devToolsExtension ? window.devToolsExtension() : f => f
+  ));
   ```
-  or [if you don't have other store enhancers and middlewares](https://github.com/zalmoxisus/redux-devtools-extension/commit/f26975cccff37f477001158019be7c9c9cb721b1):
+  with [initialState](http://redux.js.org/docs/api/createStore.html) but without middleware and enhancers arguments:
   ```javascript
-  export default function configureStore(initialState) {
-    const store = createStore(reducer, initialState, 
-      window.devToolsExtension && window.devToolsExtension()
-    );
-    return store;
-  }
+  let store = createStore(reducer, initialState, 
+    window.devToolsExtension && window.devToolsExtension()
+  );
   ```
   *or for universal (isomorphic) apps*
   ```javascript

--- a/README.md
+++ b/README.md
@@ -40,18 +40,14 @@
   ));
   ```
   - Or with [initialState](http://redux.js.org/docs/api/createStore.html) but without middleware and enhancers arguments:
+  
   ```javascript
   let store = createStore(reducer, initialState, 
     window.devToolsExtension && window.devToolsExtension()
   );
   ```
-
-  - Or for universal (isomorphic) apps
-  ```javascript
-    typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ? window.devToolsExtension() : f => f
-  ```
   
-#### With Redux DevTools
+##### 2.3 Together with Redux DevTools
   You can use this extension together with vanilla [Redux DevTools](https://github.com/gaearon/redux-devtools) as a fallback, but not both simultaneously:
   ```js
   window.devToolsExtension ? window.devToolsExtension() : DevTools.instrument()
@@ -63,10 +59,13 @@
   ```
   
   Note: passing enhancer as last argument requires redux@>=3.1.0. For older versions apply it like [here](https://github.com/zalmoxisus/redux-devtools-extension/blob/v0.4.2/examples/todomvc/store/configureStore.js) or [here](https://github.com/zalmoxisus/redux-devtools-extension/blob/v0.4.2/examples/counter/store/configureStore.js#L7-L12).
-
-#### For React Native, hybrid, desktop and server side Redux apps
+#### 3. Use with universal (isomorphic) apps
+```javascript
+  typeof window === 'object' && typeof window.devToolsExtension !== 'undefined' ? window.devToolsExtension() : f => f
+```
+#### 4. For React Native, hybrid, desktop and server side Redux apps
   Include [`Remote Redux DevTools`](https://github.com/zalmoxisus/remote-redux-devtools), and from the extension's context menu choose 'Open Remote DevTools' or press Alt+Shift+arrow up for remote monitoring.
-
+  
 ## Documentation
 
 - [FAQ](docs/FAQ.md)


### PR DESCRIPTION
I've turned my [complaints](https://github.com/zalmoxisus/redux-devtools-extension/issues/161) into some minor changes in the Readme. 
Since I couldn't find store-initialization via a function ("configureStore") anywhere in the redux-docs, I've removed it from all examples, imho this is more transparent.