### PR TITLE
Add instruction for working with file:/// URLs

### DIFF
--- a/docs/Troubleshooting.md
+++ b/docs/Troubleshooting.md
@@ -4,6 +4,8 @@
 
 Make sure you [applied the enhancer](https://github.com/zalmoxisus/redux-devtools-extension#2-use-with-redux). Note that passing enhancer as last argument requires redux@>=3.1.0. For older versions apply it like [here](https://github.com/zalmoxisus/redux-devtools-extension/blob/v0.4.2/examples/todomvc/store/configureStore.js) or [here](https://github.com/zalmoxisus/redux-devtools-extension/blob/v0.4.2/examples/counter/store/configureStore.js#L7-L12).
 
+If you develop on your local filesystem, make sure to allow Redux DevTools access to `file:///` URLs in the settings of this extension.
+
 ### It shows only the `@@INIT` action
 
 Most likely you mutate the state. Check it by [adding `redux-immutable-state-invariant` middleware](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/examples/counter/store/configureStore.js#L3).


### PR DESCRIPTION
In Chrome you must explicitly enable the extension access to file:/// URLs, otherwise it won’t work locally.

It’s currently not an issue in Firefox, because Firefox allows all URLs by default (but this my change in the future?).