### PR TITLE
Add latency to improve the performance

### DIFF
--- a/docs/API/Arguments.md
+++ b/docs/API/Arguments.md
@@ -4,6 +4,7 @@ Use `window.__REDUX_DEVTOOLS_EXTENSION__([config])` or `window.__REDUX_DEVTOOLS_
 - [`config`] *(object)*: options
   - **name** (*string*) - the instance name to be showed on the monitor page. Default value is `document.title`.
   - **actionCreators** (*array* or *object*) - action creators to dispatch remotely. See [the example](https://github.com/zalmoxisus/redux-devtools-extension/commit/477e69d8649dfcdc9bf84dd45605dab7d9775c03).
+  - **latency** (*number (in ms)*) - if more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once. It determines the performance vs speed. When setting it to `0`, all actions will be sent instantly. Default is `500 ms`.
   - **maxAge** (*number*) - maximum allowed actions to be stored on the history tree, the oldest actions are removed once maxAge is reached. Default is `50`.
   - **shouldCatchErrors** (*boolean*) - if specified as `true`, whenever there's an exception in reducers, the monitors will show the error message, and next actions will not be dispatched.
   - **shouldRecordChanges** (*boolean*) - if specified as `false`, it will not record the changes till clicking on `Start recording` button. Default is `true`.

--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -29,7 +29,7 @@ export function toContentScript(message, serializeState, serializeAction, should
   if (message.type === 'ACTION') {
     message.action = stringify(message.action, serializeAction);
     message.payload = stringify(message.payload, serializeState);
-  } else if (message.type === 'STATE') {
+  } else if (message.type === 'STATE' || message.type === 'PARTIAL_STATE') {
     if (serializeState === false) {
       message.payload = jsan.stringify(message.payload, null, null, false);
     } else {


### PR DESCRIPTION
When having frequently dispatched actions, we want to batch them instead of flooding the extension and consuming all the cpu. 

Now we're having a new parameter for that: **latency** (*number (in ms)*) - if more than one action is dispatched in this interval, all new actions will be collected and sent at once. It determines the performance vs speed. When setting it to `0`, all actions will be sent instantly. Default is `500 ms`.

The demo bellow was consuming 100% of cpu before, but now it's less than 30% (most of which being taken by React) with the default latency. By increasing further, we can avoid cpu spikes at all.

![ohyps8dh7c](https://cloud.githubusercontent.com/assets/7957859/19854795/9d2c941e-9f79-11e6-826d-1cf30f4ecafa.gif)
