### PR TITLE
Add `chrome.storage.local.remove` mock for Electron

### DIFF
--- a/src/browser/extension/chromeAPIMock.js
+++ b/src/browser/extension/chromeAPIMock.js
@@ -38,7 +38,7 @@ if (
 }
 
 if (window.isElectron) {
-  if (!chrome.storage.local) {
+  if (!chrome.storage.local || !chrome.storage.local.remove) {
     chrome.storage.local = {
       set(obj, callback) {
         Object.keys(obj).forEach(key => {
@@ -55,6 +55,19 @@ if (window.isElectron) {
         });
         if (callback) {
           callback(result);
+        }
+      },
+      // Electron ~ 1.4.6
+      remove(items, callback) {
+        if (!Array.isArray(items)) {
+          items.forEach(name => {
+            localStorage.removeItem(name);
+          });
+        } else {
+          localStorage.removeItem(items);
+        }
+        if (callback) {
+          callback();
         }
       }
     };


### PR DESCRIPTION
Currently I getting error `chrome.storage.local.remove is not a function` when I toggle dispatcher or slider on Electron, It doesn't crash just print log in the main process.

I also submit a PR to Electron (https://github.com/electron/electron/pull/7923), but I think we can backward compatibility.