### PR TITLE
Persist states right from the extension

### DIFF
--- a/src/app/api/generateInstanceId.js
+++ b/src/app/api/generateInstanceId.js
@@ -1,0 +1,5 @@
+let id = 0;
+
+export default function generateId(instanceId) {
+  return instanceId || ++id;
+}

--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -1,5 +1,6 @@
 import jsan from 'jsan';
 import importState from './importState';
+import generateId from './generateInstanceId';
 
 const listeners = {};
 export const source = '@devtools-page';
@@ -26,10 +27,6 @@ function stringify(obj, serialize) {
     }, null, true);
   }
   return jsan.stringify(obj, serialize.replacer, null, serialize.options);
-}
-
-export function generateId(instanceId) {
-  return instanceId || Math.random().toString(36).substr(2);
 }
 
 function post(message) {

--- a/src/app/containers/App.js
+++ b/src/app/containers/App.js
@@ -24,6 +24,7 @@ import LeftIcon from 'react-icons/lib/md/border-left';
 import RightIcon from 'react-icons/lib/md/border-right';
 import BottomIcon from 'react-icons/lib/md/border-bottom';
 import RemoteIcon from 'react-icons/lib/go/radio-tower';
+import PersistIcon from 'react-icons/lib/go/pin';
 
 @enhance
 class App extends Component {
@@ -33,7 +34,7 @@ class App extends Component {
 
   render() {
     const {
-      monitor, position,
+      monitor, position, togglePersist,
       dispatcherIsOpen, sliderIsOpen, options, liftedState
     } = this.props;
     const isRedux = options.lib === 'redux';
@@ -91,6 +92,10 @@ class App extends Component {
           {isRedux &&
             <LockButton locked={liftedState.isLocked} />
           }
+          <Button
+            Icon={PersistIcon}
+            onClick={togglePersist}
+          >Persist</Button>
           <DispatcherButton dispatcherIsOpen={dispatcherIsOpen} />
           <SliderButton isOpen={sliderIsOpen} />
           <ImportButton />
@@ -120,6 +125,7 @@ App.propTypes = {
   bgStore: PropTypes.object,
   liftedDispatch: PropTypes.func.isRequired,
   getReport: PropTypes.func.isRequired,
+  togglePersist: PropTypes.func.isRequired,
   selected: PropTypes.string,
   liftedState: PropTypes.object.isRequired,
   monitorState: PropTypes.object,
@@ -150,7 +156,8 @@ function mapStateToProps(state) {
 function mapDispatchToProps(dispatch) {
   return {
     liftedDispatch: bindActionCreators(liftedDispatch, dispatch),
-    getReport: bindActionCreators(getReport, dispatch)
+    getReport: bindActionCreators(getReport, dispatch),
+    togglePersist: () => { dispatch({ type: 'TOGGLE_PERSIST' }); }
   };
 }
 

--- a/src/app/middlewares/api.js
+++ b/src/app/middlewares/api.js
@@ -32,7 +32,7 @@ function toContentScript({ message, action, id, instanceId, state }) {
     type: message,
     action,
     state: nonReduxDispatch(window.store, message, instanceId, action, state),
-    id: instanceId
+    id: instanceId.replace(/^[^\/]+\//, '')
   });
 }
 
@@ -109,6 +109,9 @@ function messaging(request, sender, sendResponse) {
   }
 
   const action = { type: UPDATE_STATE, request, id: tabId };
+  if (request.instanceId) {
+    action.request.instanceId = `${tabId}/${request.instanceId}`;
+  }
   window.store.dispatch(action);
 
   if (request.type === 'EXPORT') {

--- a/src/app/middlewares/panelSync.js
+++ b/src/app/middlewares/panelSync.js
@@ -15,7 +15,7 @@ function panelDispatcher(bgConnection) {
         next({ type: SELECT_INSTANCE, selected: connections[0] });
       }
     }
-    if (action.type === LIFTED_ACTION) {
+    if (action.type === LIFTED_ACTION || action.type === 'TOGGLE_PERSIST') {
       const instances = store.getState().instances;
       const instanceId = getActiveInstance(instances);
       bgConnection.postMessage({ ...action, instanceId, id: tabId });

--- a/src/app/middlewares/windowSync.js
+++ b/src/app/middlewares/windowSync.js
@@ -8,7 +8,7 @@ const syncStores = baseStore => store => next => action => {
       instances: baseStore.getState().instances
     });
   }
-  if (action.type === LIFTED_ACTION) {
+  if (action.type === LIFTED_ACTION || action.type === 'TOGGLE_PERSIST') {
     const instances = store.getState().instances;
     const instanceId = getActiveInstance(instances);
     const id = instances.options[instanceId].connectionId;

--- a/src/app/reducers/background/index.js
+++ b/src/app/reducers/background/index.js
@@ -1,8 +1,10 @@
 import { combineReducers } from 'redux';
 import instances from 'remotedev-app/lib/reducers/instances';
+import persistStates from './persistStates';
 
 const rootReducer = combineReducers({
-  instances
+  instances,
+  persistStates
 });
 
 export default rootReducer;

--- a/src/app/reducers/background/persistStates.js
+++ b/src/app/reducers/background/persistStates.js
@@ -1,0 +1,4 @@
+export default function persistStates(state = false, action) {
+  if (action.type === 'TOGGLE_PERSIST') return !state;
+  return state;
+}

--- a/src/browser/extension/background/openWindow.js
+++ b/src/browser/extension/background/openWindow.js
@@ -34,7 +34,7 @@ export default function openDevToolsWindow(position) {
     });
   }
 
-  let params = { left: 0, top: 0, width: 350, height: window.screen.availHeight };
+  let params = { left: 0, top: 0, width: 380, height: window.screen.availHeight };
   let url = 'window.html';
   switch (position) {
     case 'devtools-right':

--- a/src/browser/extension/inject/contentScript.js
+++ b/src/browser/extension/inject/contentScript.js
@@ -59,8 +59,11 @@ function tryCatch(fn, args) {
 
 function send(message) {
   if (!connected) connect();
-  if (message.type === 'INIT_INSTANCE') bg.postMessage({ name: 'INIT_INSTANCE' });
-  else bg.postMessage({ name: 'RELAY', message });
+  if (message.type === 'INIT_INSTANCE') {
+    bg.postMessage({ name: 'INIT_INSTANCE', instanceId: message.instanceId });
+  } else {
+    bg.postMessage({ name: 'RELAY', message });
+  }
 }
 
 // Resend messages from the page to the background script

--- a/src/browser/extension/inject/pageScript.js
+++ b/src/browser/extension/inject/pageScript.js
@@ -8,9 +8,9 @@ import { getLocalFilter, isFiltered, filterState, startingFrom } from '../../../
 import notifyErrors from '../../../app/api/notifyErrors';
 import importState from '../../../app/api/importState';
 import openWindow from '../../../app/api/openWindow';
+import generateId from '../../../app/api/generateInstanceId';
 import {
-  updateStore, toContentScript, sendMessage, setListener, connect, disconnect,
-  generateId, isInIframe
+  updateStore, toContentScript, sendMessage, setListener, connect, disconnect, isInIframe
 } from '../../../app/api';
 
 const source = '@devtools-page';


### PR DESCRIPTION
Currently the extension is adding [`persistState` enhancer](https://github.com/gaearon/redux-devtools/blob/master/src/persistState.js), which store every change in `localStorage`. However, it has issues with:
- [filling up local storage very quickly](https://github.com/gaearon/redux-devtools/issues/298)
- [changing url](https://github.com/zalmoxisus/redux-devtools-extension/issues/274)
- [throwing on unserializable data](https://github.com/gaearon/redux-devtools/issues/262).

We already have all the data from the store on the extension part, and can easily restore it without `persistState` enhancer. This PR adds a new button:
<img width="534" alt="redux_devtools" src="https://cloud.githubusercontent.com/assets/7957859/21522403/f1fa68d8-cd0d-11e6-804d-fd777de26009.png">


By toggling the button, the states won't be removed from the monitor on unloading the page and will be restored on reload:
![persit](https://cloud.githubusercontent.com/assets/7957859/21522440/3d73635a-cd0e-11e6-8635-2b66a4a2ed07.gif)

We should show when the button is toggled, which will be addressed in `3.0` when we move to [the new UI](https://github.com/zalmoxisus/remotedev-monitor-components).