### PR TITLE
Fix typo, link to `create-react-app` config

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,7 +154,7 @@ or with middlewares and enhancers:
    // other store enhancers if any
  ));
  ```
->  You'll have to add `'process.env.NODE_ENV': JSON.stringify('production')` in your Webpack config for the production bundle ([to envify](https://github.com/gaearon/redux-devtools/blob/master/docs/Walkthrough.md#exclude-devtools-from-production-builds)). If you use `react-create-app`, it already does it for you.
+>  You'll have to add `'process.env.NODE_ENV': JSON.stringify('production')` in your Webpack config for the production bundle ([to envify](https://github.com/gaearon/redux-devtools/blob/master/docs/Walkthrough.md#exclude-devtools-from-production-builds)). If you use `create-react-app`, [it already does it for you.](https://github.com/facebookincubator/create-react-app/blob/master/packages/react-scripts/config/webpack.config.prod.js#L253-L257)
 
  If you're already checking `process.env.NODE_ENV` when creating the store, include `redux-devtools-extension/logOnly` for production enviroment.
 


### PR DESCRIPTION
Correct note about usage in production: changing `react-create-app` to `create-react-app` and linking to the corresponding section of `create-react-app`'s `webpack.config.prod.js`.