### PR TITLE
Fix submodule typings

### DIFF
--- a/npm-package/developmentOnly.d.ts
+++ b/npm-package/developmentOnly.d.ts
@@ -1,0 +1,1 @@
+export * from "redux-devtools-extension";

--- a/npm-package/index.d.ts
+++ b/npm-package/index.d.ts
@@ -1,167 +1,161 @@
-declare module "redux-devtools-extension" {
-  import {Action, ActionCreator, GenericStoreEnhancer, compose} from "redux";
+import {Action, ActionCreator, GenericStoreEnhancer, compose} from "redux";
 
-  export interface EnhancerOptions {
+export interface EnhancerOptions {
+  /**
+   * the instance name to be showed on the monitor page. Default value is `document.title`.
+   * If not specified and there's no document title, it will consist of `tabId` and `instanceId`.
+   */
+  name?: string;
+  /**
+   * action creators functions to be available in the Dispatcher.
+   */
+  actionCreators?: ActionCreator<any>[] | {[key: string]: ActionCreator<any>};
+  /**
+   * if more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once.
+   * It is the joint between performance and speed. When set to `0`, all actions will be sent instantly.
+   * Set it to a higher value when experiencing perf issues (also `maxAge` to a lower value).
+   *
+   * @default 500 ms.
+   */
+  latency?: number;
+  /**
+   * (> 1) - maximum allowed actions to be stored in the history tree. The oldest actions are removed once maxAge is reached. It's critical for performance.
+   *
+   * @default 50
+   */
+  maxAge?: number;
+  /**
+   * - `undefined` - will use regular `JSON.stringify` to send data (it's the fast mode).
+   * - `false` - will handle also circular references.
+   * - `true` - will handle also date, regex, undefined, error objects, symbols, maps, sets and functions.
+   * - object, which contains `date`, `regex`, `undefined`, `error`, `symbol`, `map`, `set` and `function` keys.
+   *   For each of them you can indicate if to include (by setting as `true`).
+   *   For `function` key you can also specify a custom function which handles serialization.
+   *   See [`jsan`](https://github.com/kolodny/jsan) for more details.
+   */
+  serialize?: boolean | {
+  date?: boolean;
+  regex?: boolean;
+  undefined?: boolean;
+  error?: boolean;
+  symbol?: boolean;
+  map?: boolean;
+  set?: boolean;
+  function?: boolean | Function;
+  };
+  /**
+   * function which takes `action` object and id number as arguments, and should return `action` object back.
+   */
+  actionSanitizer?: <A extends Action>(action: A, id: number) => A;
+  /**
+   * function which takes `state` object and index as arguments, and should return `state` object back.
+   */
+  stateSanitizer?: <S>(state: S, index: number) => S;
+  /**
+   * *string or array of strings as regex* - actions types to be hidden / shown in the monitors (while passed to the reducers).
+   * If `actionsWhitelist` specified, `actionsBlacklist` is ignored.
+   */
+  actionsBlacklist?: string | string[];
+  /**
+   * *string or array of strings as regex* - actions types to be hidden / shown in the monitors (while passed to the reducers).
+   * If `actionsWhitelist` specified, `actionsBlacklist` is ignored.
+   */
+  actionsWhitelist?: string | string[];
+  /**
+   * called for every action before sending, takes `state` and `action` object, and returns `true` in case it allows sending the current data to the monitor.
+   * Use it as a more advanced version of `actionsBlacklist`/`actionsWhitelist` parameters.
+   */
+  predicate?: <S, A extends Action>(state: S, action: A) => boolean;
+  /**
+   * if specified as `false`, it will not record the changes till clicking on `Start recording` button.
+   * Available only for Redux enhancer, for others use `autoPause`.
+   *
+   * @default true
+   */
+  shouldRecordChanges?: boolean;
+  /**
+   * if specified, whenever clicking on `Pause recording` button and there are actions in the history log, will add this action type.
+   * If not specified, will commit when paused. Available only for Redux enhancer.
+   *
+   * @default "@@PAUSED""
+   */
+  pauseActionType?: string;
+  /**
+   * auto pauses when the extension’s window is not opened, and so has zero impact on your app when not in use.
+   * Not available for Redux enhancer (as it already does it but storing the data to be sent).
+   *
+   * @default false
+   */
+  autoPause?: boolean;
+  /**
+   * if specified as `true`, it will not allow any non-monitor actions to be dispatched till clicking on `Unlock changes` button.
+   * Available only for Redux enhancer.
+   *
+   * @default false
+   */
+  shouldStartLocked?: boolean;
+  /**
+   * if set to `false`, will not recompute the states on hot reloading (or on replacing the reducers). Available only for Redux enhancer.
+   *
+   * @default true
+   */
+  shouldHotReload?: boolean;
+  /**
+   * if specified as `true`, whenever there's an exception in reducers, the monitors will show the error message, and next actions will not be dispatched.
+   *
+   * @default false
+   */
+  shouldCatchErrors?: boolean;
+  /**
+   * If you want to restrict the extension, specify the features you allow.
+   * If not specified, all of the features are enabled. When set as an object, only those included as `true` will be allowed.
+   * Note that except `true`/`false`, `import` and `export` can be set as `custom` (which is by default for Redux enhancer), meaning that the importing/exporting occurs on the client side.
+   * Otherwise, you'll get/set the data right from the monitor part.
+   */
+  features?: {
     /**
-     * the instance name to be showed on the monitor page. Default value is `document.title`.
-     * If not specified and there's no document title, it will consist of `tabId` and `instanceId`.
+     * start/pause recording of dispatched actions
      */
-    name?: string;
+    pause?: boolean;
     /**
-     * action creators functions to be available in the Dispatcher.
+     * lock/unlock dispatching actions and side effects
      */
-    actionCreators?: ActionCreator<any>[] | {[key: string]: ActionCreator<any>};
+    lock?: boolean;
     /**
-     * if more than one action is dispatched in the indicated interval, all new actions will be collected and sent at once.
-     * It is the joint between performance and speed. When set to `0`, all actions will be sent instantly.
-     * Set it to a higher value when experiencing perf issues (also `maxAge` to a lower value).
-     *
-     * @default 500 ms.
+     * persist states on page reloading
      */
-    latency?: number;
+    persist?: boolean;
     /**
-     * (> 1) - maximum allowed actions to be stored in the history tree. The oldest actions are removed once maxAge is reached. It's critical for performance.
-     *
-     * @default 50
+     * export history of actions in a file
      */
-    maxAge?: number;
+    export?: boolean | "custom";
     /**
-     * - `undefined` - will use regular `JSON.stringify` to send data (it's the fast mode).
-     * - `false` - will handle also circular references.
-     * - `true` - will handle also date, regex, undefined, error objects, symbols, maps, sets and functions.
-     * - object, which contains `date`, `regex`, `undefined`, `error`, `symbol`, `map`, `set` and `function` keys.
-     *   For each of them you can indicate if to include (by setting as `true`).
-     *   For `function` key you can also specify a custom function which handles serialization.
-     *   See [`jsan`](https://github.com/kolodny/jsan) for more details.
+     * import history of actions from a file
      */
-    serialize?: boolean | {
-		date?: boolean;
-		regex?: boolean;
-		undefined?: boolean;
-		error?: boolean;
-		symbol?: boolean;
-		map?: boolean;
-		set?: boolean;
-		function?: boolean | Function;
-    };
+    import?: boolean | "custom";
     /**
-     * function which takes `action` object and id number as arguments, and should return `action` object back.
+     * jump back and forth (time travelling)
      */
-    actionSanitizer?: <A extends Action>(action: A, id: number) => A;
+    jump?: boolean;
     /**
-     * function which takes `state` object and index as arguments, and should return `state` object back.
+     * skip (cancel) actions
      */
-    stateSanitizer?: <S>(state: S, index: number) => S;
+    skip?: boolean;
     /**
-     * *string or array of strings as regex* - actions types to be hidden / shown in the monitors (while passed to the reducers).
-     * If `actionsWhitelist` specified, `actionsBlacklist` is ignored.
+     * drag and drop actions in the history list
      */
-    actionsBlacklist?: string | string[];
+    reorder?: boolean;
     /**
-     * *string or array of strings as regex* - actions types to be hidden / shown in the monitors (while passed to the reducers).
-     * If `actionsWhitelist` specified, `actionsBlacklist` is ignored.
+     * dispatch custom actions or action creators
      */
-    actionsWhitelist?: string | string[];
+    dispatch?: boolean;
     /**
-     * called for every action before sending, takes `state` and `action` object, and returns `true` in case it allows sending the current data to the monitor.
-     * Use it as a more advanced version of `actionsBlacklist`/`actionsWhitelist` parameters.
+     * generate tests for the selected actions
      */
-    predicate?: <S, A extends Action>(state: S, action: A) => boolean;
-    /**
-     * if specified as `false`, it will not record the changes till clicking on `Start recording` button.
-     * Available only for Redux enhancer, for others use `autoPause`.
-     *
-     * @default true
-     */
-    shouldRecordChanges?: boolean;
-    /**
-     * if specified, whenever clicking on `Pause recording` button and there are actions in the history log, will add this action type.
-     * If not specified, will commit when paused. Available only for Redux enhancer.
-     *
-     * @default "@@PAUSED""
-     */
-    pauseActionType?: string;
-    /**
-     * auto pauses when the extension’s window is not opened, and so has zero impact on your app when not in use.
-     * Not available for Redux enhancer (as it already does it but storing the data to be sent).
-     *
-     * @default false
-     */
-    autoPause?: boolean;
-    /**
-     * if specified as `true`, it will not allow any non-monitor actions to be dispatched till clicking on `Unlock changes` button.
-     * Available only for Redux enhancer.
-     *
-     * @default false
-     */
-    shouldStartLocked?: boolean;
-    /**
-     * if set to `false`, will not recompute the states on hot reloading (or on replacing the reducers). Available only for Redux enhancer.
-     *
-     * @default true
-     */
-    shouldHotReload?: boolean;
-    /**
-     * if specified as `true`, whenever there's an exception in reducers, the monitors will show the error message, and next actions will not be dispatched.
-     *
-     * @default false
-     */
-    shouldCatchErrors?: boolean;
-    /**
-     * If you want to restrict the extension, specify the features you allow.
-     * If not specified, all of the features are enabled. When set as an object, only those included as `true` will be allowed.
-     * Note that except `true`/`false`, `import` and `export` can be set as `custom` (which is by default for Redux enhancer), meaning that the importing/exporting occurs on the client side.
-     * Otherwise, you'll get/set the data right from the monitor part.
-     */
-    features?: {
-      /**
-       * start/pause recording of dispatched actions
-       */
-      pause?: boolean;
-      /**
-       * lock/unlock dispatching actions and side effects
-       */
-      lock?: boolean;
-      /**
-       * persist states on page reloading
-       */
-      persist?: boolean;
-      /**
-       * export history of actions in a file
-       */
-      export?: boolean | "custom";
-      /**
-       * import history of actions from a file
-       */
-      import?: boolean | "custom";
-      /**
-       * jump back and forth (time travelling)
-       */
-      jump?: boolean;
-      /**
-       * skip (cancel) actions
-       */
-      skip?: boolean;
-      /**
-       * drag and drop actions in the history list
-       */
-      reorder?: boolean;
-      /**
-       * dispatch custom actions or action creators
-       */
-      dispatch?: boolean;
-      /**
-       * generate tests for the selected actions
-       */
-      test?: boolean;
-    };
-  }
-
-  export function composeWithDevTools(...funcs: Function[]): GenericStoreEnhancer;
-  export function composeWithDevTools(options: EnhancerOptions): typeof compose;
-  export function devToolsEnhancer(options: EnhancerOptions): GenericStoreEnhancer;
+    test?: boolean;
+  };
 }
 
-declare module "redux-devtools-extension/*" {
-  export * from "redux-devtools-extension";
-}
+export function composeWithDevTools(...funcs: Function[]): GenericStoreEnhancer;
+export function composeWithDevTools(options: EnhancerOptions): typeof compose;
+export function devToolsEnhancer(options: EnhancerOptions): GenericStoreEnhancer;

--- a/npm-package/logOnly.d.ts
+++ b/npm-package/logOnly.d.ts
@@ -1,0 +1,1 @@
+export * from "redux-devtools-extension";

--- a/npm-package/logOnlyInProduction.d.ts
+++ b/npm-package/logOnlyInProduction.d.ts
@@ -1,0 +1,1 @@
+export * from "redux-devtools-extension";

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -3,7 +3,6 @@
   "version": "2.13.1",
   "description": "Wrappers for Redux DevTools Extension.",
   "main": "index.js",
-  "types": "./index.d.ts",
   "repository": {
     "type": "git",
     "url": "https://github.com/zalmoxisus/redux-devtools-extension"


### PR DESCRIPTION
Sorry, my previous PR did not work with the submodules (e.g. `redux-devtools-extension/developmentOnly`) because I didn't use those, this fixes that.