### PR TITLE
Update E2E test for Electron 1.6

### DIFF
--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "chromedriver": "^2.27.2",
     "co-mocha": "^1.1.3",
     "cross-env": "^1.0.8",
-    "electron": "^1.4.4",
+    "electron": "^1.6.6",
     "enzyme": "^2.3.0",
     "eslint": "^1.7.1",
     "eslint-config-airbnb": "^0.1.0",

--- a/test/.eslintrc
+++ b/test/.eslintrc
@@ -3,7 +3,7 @@
     "mocha": true
   },
   "globals": {
-    "WebInspector": true
+    "UI": true
   },
   "rules": {
     "no-unused-expressions": 0

--- a/test/electron/devpanel.spec.js
+++ b/test/electron/devpanel.spec.js
@@ -41,11 +41,11 @@ describe('DevTools panel for Electron', function() {
         if (attempts === 0) {
           return callback('Redux panel not found');
         }
-        const tabs = WebInspector.inspectorView._tabbedPane._tabs;
+        const tabs = UI.inspectorView._tabbedPane._tabs;
         const idList = tabs.map(tab => tab.id);
         const reduxPanelId = 'chrome-extension://redux-devtoolsRedux';
         if (idList.indexOf(reduxPanelId) !== -1) {
-          WebInspector.inspectorView.showPanel(reduxPanelId);
+          UI.inspectorView.showPanel(reduxPanelId);
           return callback(reduxPanelId);
         }
         attempts--;
@@ -68,8 +68,12 @@ describe('DevTools panel for Electron', function() {
   });
 
   it('should contain INIT action', async () => {
-    const val = await this.driver.findElement(webdriver.By.xpath('//div[contains(@class, "actionListRows-")]'))
-      .getText();
+    const element = await this.driver.wait(
+      webdriver.until.elementLocated(webdriver.By.xpath('//div[contains(@class, "actionListRows-")]')),
+      5000,
+      'Element not found'
+    );
+    const val = await element.getText();
     expect(val).toMatch(/@@INIT/);
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -1738,9 +1738,9 @@ electron-download@^3.0.1:
     semver "^5.3.0"
     sumchecker "^1.2.0"
 
-electron@^1.4.4:
-  version "1.4.14"
-  resolved "https://registry.yarnpkg.com/electron/-/electron-1.4.14.tgz#e374b76ccdc432bccad9bb3ce1add453bf5648b4"
+electron@^1.6.6:
+  version "1.6.8"
+  resolved "https://registry.yarnpkg.com/electron/-/electron-1.6.8.tgz#41cbbe7272ccd93339c040f856c0d6372a4ddb07"
   dependencies:
     electron-download "^3.0.1"
     extract-zip "^1.0.3"
@@ -2083,7 +2083,7 @@ fast-levenshtein@~2.0.4:
   version "2.0.6"
   resolved "https://registry.yarnpkg.com/fast-levenshtein/-/fast-levenshtein-2.0.6.tgz#3d8a5c66883a16a30ca8643e851f19baa7797917"
 
-fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.6, fbjs@^0.8.8:
+fbjs@^0.8.1, fbjs@^0.8.4:
   version "0.8.8"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.8.tgz#02f1b6e0ea0d46c24e0b51a2d24df069563a5ad6"
   dependencies:
@@ -2095,7 +2095,7 @@ fbjs@^0.8.1, fbjs@^0.8.4, fbjs@^0.8.5, fbjs@^0.8.6, fbjs@^0.8.8:
     setimmediate "^1.0.5"
     ua-parser-js "^0.7.9"
 
-fbjs@^0.8.9:
+fbjs@^0.8.5, fbjs@^0.8.6, fbjs@^0.8.8, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -3220,11 +3220,7 @@ js-yaml@3.4.5:
     argparse "^1.0.2"
     esprima "^2.6.0"
 
-jsan@^3.1.0, jsan@^3.1.2, jsan@^3.1.3:
-  version "3.1.5"
-  resolved "https://registry.yarnpkg.com/jsan/-/jsan-3.1.5.tgz#8144b968ace7db092914a3639e9768181d686f61"
-
-jsan@^3.1.9:
+jsan@^3.1.0, jsan@^3.1.2, jsan@^3.1.3, jsan@^3.1.9:
   version "3.1.9"
   resolved "https://registry.yarnpkg.com/jsan/-/jsan-3.1.9.tgz#2705676c1058f0a7d9ac266ad036a5769cfa7c96"
 
@@ -5337,14 +5333,7 @@ redux-devtools-chart-monitor@^1.6.1:
     react-pure-render "^1.0.2"
     redux-devtools-themes "^1.0.0"
 
-redux-devtools-instrument@^1.0.1:
-  version "1.7.1"
-  resolved "https://registry.yarnpkg.com/redux-devtools-instrument/-/redux-devtools-instrument-1.7.1.tgz#30a28b76ac7fcfd0b8d4295ab6178cfc85088f6c"
-  dependencies:
-    lodash "^4.2.0"
-    symbol-observable "^1.0.2"
-
-redux-devtools-instrument@^1.8.1:
+redux-devtools-instrument@^1.0.1, redux-devtools-instrument@^1.8.1:
   version "1.8.1"
   resolved "https://registry.yarnpkg.com/redux-devtools-instrument/-/redux-devtools-instrument-1.8.1.tgz#aa74eea651338b941004a4685edd58b81626fd1f"
   dependencies:
@@ -5749,17 +5738,17 @@ selenium-webdriver@^3.0.1:
     tmp "0.0.30"
     xml2js "^0.4.17"
 
-"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@4 || 5", "semver@^2.3.0 || 3.x || 4 || 5", semver@^5.3.0, semver@~5.3.0:
-  version "5.3.0"
-  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
-
-semver@5.1.0, semver@~5.1.0:
+"semver@2 >=2.2.1 || 3.x || 4 || 5", "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", "semver@4 || 5", semver@5.1.0, "semver@^2.3.0 || 3.x || 4 || 5", semver@~5.1.0:
   version "5.1.0"
   resolved "https://registry.yarnpkg.com/semver/-/semver-5.1.0.tgz#85f2cf8550465c4df000cf7d86f6b054106ab9e5"
 
 semver@^4.1.0:
   version "4.3.6"
   resolved "https://registry.yarnpkg.com/semver/-/semver-4.3.6.tgz#300bc6e0e86374f7ba61068b5b1ecd57fc6532da"
+
+semver@^5.3.0, semver@~5.3.0:
+  version "5.3.0"
+  resolved "https://registry.yarnpkg.com/semver/-/semver-5.3.0.tgz#9b2ce5d3de02d17c6012ad326aa6b4d0cf54f94f"
 
 sequencify@~0.0.7:
   version "0.0.7"


### PR DESCRIPTION
Update E2E test for latest version (1.6.6) of Electron, a little different is `WebInspector` instance in devtools have been renamed to `UI`.