### PR TITLE
fix passing wrong serialization config on init

### DIFF
--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -218,7 +218,7 @@ export function connect(preConfig) {
   const init = (state, liftedData) => {
     const message = {
       type: 'INIT',
-      payload: stringify(state, config),
+      payload: stringify(state, config.serialize),
       instanceId: id,
       source
     };

--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -31,13 +31,15 @@ export function getSeralizeParameter(config, param) {
   if (serialize) {
     if (serialize === true) return { options: true };
     if (serialize.immutable) {
+      const immutableSerializer = seralizeImmutable(serialize.immutable, serialize.refs);
       return {
-        replacer: seralizeImmutable(serialize.immutable, serialize.refs).replacer,
+        replacer: immutableSerializer.replacer,
+        reviver: immutableSerializer.reviver,
         options: serialize.options || true
       };
     }
-    if (!serialize.replacer) return { options: serialize.options };
-    return { replacer: serialize.replacer, options: serialize.options || true };
+    if (!serialize.replacer && !serialize.reviver) return { options: serialize.options };
+    return { replacer: serialize.replacer, reviver: serialize.reviver, options: serialize.options || true };
   }
 
   const value = config[param];


### PR DESCRIPTION
During connection initialization, state is not serialized with respect to serialization options.
This simple fix is sending proper serialization options to `stringify`.

Edit: also added missing reviver in `getSeralizeParameter`. I added it for immutable serialization also, but I am not using ImmutableJS, so someone should double check if it is needed there. By analogy, it seems it is.