### PR TITLE
Update README instructions resulting

### DIFF
--- a/README.md
+++ b/README.md
@@ -48,7 +48,7 @@ In case ESLint is configured to not allow using the underscore dangle, wrap it l
 + /* eslint-disable no-underscore-dangle */
   const store = createStore(
    reducer, /* preloadedState, */
-   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+   window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : f => f
   );
 + /* eslint-enable */
 ```


### PR DESCRIPTION
In our dev/staging/production environments we had the issue that users without the chrome extension were unable to open our application.

The store initialization configuration we used was

```
  const store = createStore(reducer, initialStates, compose(
    applyMiddleware(...middlewares),
    window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
  ));
```

However due to us overlooking the advanced setup, we broke our store.
This of course is mentioned in https://github.com/zalmoxisus/redux-devtools-extension#12-advanced-store-setup how to replace `redux`'s `compose` with the extension's.

However to make the `Basic Setup` more copy-paste friendly I suggest it returns a piping function by default.
This would work in `Basic` and `Advanced Setup`s.