### PR TITLE
Add browser field and browser versions of the main libraries

### DIFF
--- a/npm-package/developmentOnly.browser.d.ts
+++ b/npm-package/developmentOnly.browser.d.ts
@@ -1,0 +1,1 @@
+export * from "redux-devtools-extension";

--- a/npm-package/developmentOnly.browser.js
+++ b/npm-package/developmentOnly.browser.js
@@ -1,0 +1,25 @@
+"use strict";
+
+import { compose } from 'redux';
+
+const composeWithDevTools = (
+  process.env.NODE_ENV !== 'production' && typeof window !== 'undefined' &&
+  window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ :
+    function() {
+      if (arguments.length === 0) return undefined;
+      if (typeof arguments[0] === 'object') return compose;
+      return compose.apply(null, arguments);
+    }
+);
+
+export composeWithDevTools;
+
+const devToolsEnhancer = (
+  process.env.NODE_ENV !== 'production' && typeof window !== 'undefined' &&
+  window.__REDUX_DEVTOOLS_EXTENSION__ ?
+    window.__REDUX_DEVTOOLS_EXTENSION__ :
+    function() { return function(noop) { return noop; } }
+);
+
+export devToolsEnhancer;

--- a/npm-package/index.browser.d.ts
+++ b/npm-package/index.browser.d.ts
@@ -1,0 +1,1 @@
+export * from "redux-devtools-extension";

--- a/npm-package/index.browser.js
+++ b/npm-package/index.browser.js
@@ -1,0 +1,23 @@
+"use strict";
+
+import { compose } from "redux";
+
+const composeWithDevTools = (
+  typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ ?
+    window.__REDUX_DEVTOOLS_EXTENSION_COMPOSE__ :
+    function() {
+      if (arguments.length === 0) return undefined;
+      if (typeof arguments[0] === 'object') return compose;
+      return compose.apply(null, arguments);
+    }
+);
+
+export composeWithDevTools;
+
+const devToolsEnhancer = (
+  typeof window !== 'undefined' && window.__REDUX_DEVTOOLS_EXTENSION__ ?
+    window.__REDUX_DEVTOOLS_EXTENSION__ :
+    function() { return function(noop) { return noop; } }
+);
+
+export devToolsEnhancer;

--- a/npm-package/package.json
+++ b/npm-package/package.json
@@ -3,6 +3,10 @@
   "version": "2.13.2",
   "description": "Wrappers for Redux DevTools Extension.",
   "main": "index.js",
+  "browser": {
+      "./developmentOnly.js": "./developmentOnly.browser.js",
+      "./index.js": "./index.browser.js"
+  },
   "repository": {
     "type": "git",
     "url": "https://github.com/zalmoxisus/redux-devtools-extension"


### PR DESCRIPTION
Hey.

This PR adds a [browser field](https://github.com/defunctzombie/package-browser-field-spec) and browsers versions of the main files used by theh npm package but using ES6 imports instead of CommonJS `require()`.

This allows bundlers like webpack and rollup to apply tree-shaking and avoid putting all the code from the redux package in the generated bundle, so reducing the bundle size in some cases. =)

Any questions or sugestions, please, feel free to ask or suggest.