### PR TITLE
don't serialize window objects, fixes #337

### DIFF
--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -8,6 +8,13 @@ import generateId from './generateInstanceId';
 const listeners = {};
 export const source = '@devtools-page';
 
+function windowReplacer(key, value) {
+  if (value && value.window === value) {
+    return '[WINDOW]';
+  }
+  return value;
+}
+
 function tryCatchStringify(obj) {
   try {
     return JSON.stringify(obj);
@@ -15,7 +22,7 @@ function tryCatchStringify(obj) {
     /* eslint-disable no-console */
     if (process.env.NODE_ENV !== 'production') console.log('Failed to stringify', err);
     /* eslint-enable no-console */
-    return jsan.stringify(obj, null, null, { circular: '[CIRCULAR]', date: true });
+    return jsan.stringify(obj, windowReplacer, null, { circular: '[CIRCULAR]', date: true });
   }
 }
 


### PR DESCRIPTION
If a payload contains a reference to a cross-domain iframe window, it may break serialization.

Rather than give up on serialization altogether, try to avoid serializing any window objects if they are found.  I think this is probably fine in most cases, I doubt anyone purposely passes a window object in a redux action.