### PR TITLE
Fix bug where duplicate actions are dispatched in a multi-store app

### DIFF
--- a/src/app/api/index.js
+++ b/src/app/api/index.js
@@ -5,6 +5,7 @@ import { getLocalFilter, isFiltered } from './filters';
 import importState from './importState';
 import generateId from './generateInstanceId';
 
+let hasSetMessageListener = false;
 const listeners = {};
 export const source = '@devtools-page';
 
@@ -120,7 +121,11 @@ function handleMessages(event) {
 
 export function setListener(onMessage, instanceId) {
   listeners[instanceId] = onMessage;
-  window.addEventListener('message', handleMessages, false);
+
+  if (!hasSetMessageListener) {
+    window.addEventListener('message', handleMessages, false);
+    hasSetMessageListener = true;
+  }
 }
 
 const liftListener = (listener, config) => message => {


### PR DESCRIPTION
**Bug Description**
Currently, when setting up `redux-devtools-extension` in an app with multiple redux stores, the [`init`](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/src/browser/extension/inject/pageScript.js#L236) function is called once for each store using the extension (via `__REDUX_DEVTOOLS_EXTENSION__` or `__REDUX_DEVTOOLS_EXTENSION_COMPOSE__`). The `init` function calls [`setListener`](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/src/app/api/index.js#L121) which in turn calls

```javascript
window.addEventListener('message', handleMessages, false)
```

once per store using the extension. So if an app has two redux stores connected to the devtools, then `handleMessages` gets attached as an event listener twice, which results in actions sent through the `Dispatcher` to be dispatched twice (because `handleMessages` is incorrectly called twice).

**Proposed Solution**
This PR changes the behavior of `setListener` to only add `handleMessages` as an event listener exactly once.

**Temporary Workaround (for Chrome users)**
For anyone that finds this and is experiencing this issue, you can paste

```javascript
window.removeEventListener('message', getEventListeners(window).message.find(o => o.listener.name === 'handleMessages').listener)
```
into the dev console to remove one of the `handleMessages` event listeners.