### PR TITLE
Add required type for StoreEnhancer in type definition of npm package

### DIFF
--- a/npm-package/index.d.ts
+++ b/npm-package/index.d.ts
@@ -156,6 +156,6 @@ export interface EnhancerOptions {
   };
 }
 
-export function composeWithDevTools(...funcs: Function[]): StoreEnhancer;
+export function composeWithDevTools(...funcs: Function[]): StoreEnhancer<any>;
 export function composeWithDevTools(options: EnhancerOptions): typeof compose;
-export function devToolsEnhancer(options: EnhancerOptions): StoreEnhancer;
+export function devToolsEnhancer(options: EnhancerOptions): StoreEnhancer<any>;


### PR DESCRIPTION
Related to #519, it's a fix for any projects still used Redux `v3`. Also tested with Redux `v4`.