### PR TITLE
Restore store typings (Fix #539)

### DIFF
--- a/npm-package/index.d.ts
+++ b/npm-package/index.d.ts
@@ -156,6 +156,6 @@ export interface EnhancerOptions {
   };
 }
 
-export function composeWithDevTools(...funcs: Function[]): StoreEnhancer<any>;
+export function composeWithDevTools<StoreExt, StateExt>(...funcs: Array<StoreEnhancer<StoreExt, StateExt>>): StoreEnhancer<StoreExt, StateExt>;
 export function composeWithDevTools(options: EnhancerOptions): typeof compose;
 export function devToolsEnhancer(options: EnhancerOptions): StoreEnhancer<any>;


### PR DESCRIPTION
Typing `funcs` and StoreEnhancer as a generic of `any` causes anything using the result to lose typings.

This restores the typings to the resulting StoreEnhancer