### PR TITLE
Workaround for new Chrome limit on message size

### DIFF
--- a/src/app/middlewares/api.js
+++ b/src/app/middlewares/api.js
@@ -12,6 +12,7 @@ const connections = {
   panel: {},
   monitor: {}
 };
+const chunks = {};
 let monitors = 0;
 let isMonitored = false;
 
@@ -122,8 +123,21 @@ function messaging(request, sender, sendResponse) {
   }
 
   const action = { type: UPDATE_STATE, request, id: tabId };
+  const instanceId = `${tabId}/${request.instanceId}`;
+  if (request.split) {
+    if (request.split === 'start') {
+      chunks[instanceId] = request;
+      return;
+    }
+    if (request.split === 'chunk') {
+      chunks[instanceId][request.chunk[0]] = (chunks[instanceId][request.chunk[0]] || '') + request.chunk[1];
+      return;
+    }
+    action.request = chunks[instanceId];
+    delete chunks[instanceId];
+  }
   if (request.instanceId) {
-    action.request.instanceId = `${tabId}/${request.instanceId}`;
+    action.request.instanceId = instanceId;
   }
   window.store.dispatch(action);
 

--- a/src/browser/extension/inject/contentScript.js
+++ b/src/browser/extension/inject/contentScript.js
@@ -1,7 +1,8 @@
 import { injectOptions, isAllowed } from '../options/syncOptions';
 const source = '@devtools-extension';
 const pageSource = '@devtools-page';
-const maxChromeMsgSize = 32 * 1024 * 1024 - 1048576; // 32 - 1 MB (1 MB reserved for other object's parts)
+// Chrome message limit is 64 MB, but we're using 32 MB to include other object's parts
+const maxChromeMsgSize = 32 * 1024 * 1024;
 let connected = false;
 let bg;
 

--- a/src/browser/extension/inject/contentScript.js
+++ b/src/browser/extension/inject/contentScript.js
@@ -1,5 +1,7 @@
 import { injectOptions, isAllowed } from '../options/syncOptions';
 const source = '@devtools-extension';
+const pageSource = '@devtools-page';
+const maxChromeMsgSize = 32 * 1024 * 1024 - 1048576; // 32 - 1 MB (1 MB reserved for other object's parts)
 let connected = false;
 let bg;
 
@@ -48,6 +50,36 @@ function tryCatch(fn, args) {
   try {
     return fn(args);
   } catch (err) {
+    if (err.message === 'Message length exceeded maximum allowed length.') {
+      const instanceId = args.instanceId;
+      const newArgs = { split: 'start' };
+      const toSplit = [];
+      let size = 0;
+      let arg;
+      Object.keys(args).map(key => {
+        arg = args[key];
+        if (typeof arg === 'string') {
+          size += arg.length;
+          if (size > maxChromeMsgSize) {
+            toSplit.push([key, arg]);
+            return;
+          }
+        }
+        newArgs[key] = arg;
+      });
+      fn(newArgs);
+      for (let i = 0; i < toSplit.length; i++) {
+        for (let j = 0; j < toSplit[i][1].length; j += maxChromeMsgSize) {
+          fn({
+            instanceId,
+            source: pageSource,
+            split: 'chunk',
+            chunk: [toSplit[i][0], toSplit[i][1].substr(j, maxChromeMsgSize)]
+          });
+        }
+      }
+      return fn({ instanceId, source: pageSource, split: 'end' });
+    }
     handleDisconnect();
     /* eslint-disable no-console */
     if (process.env.NODE_ENV !== 'production') console.error('Failed to send message', err);
@@ -69,7 +101,7 @@ function handleMessages(event) {
   if (!isAllowed()) return;
   if (!event || event.source !== window || typeof event.data !== 'object') return;
   const message = event.data;
-  if (message.source !== '@devtools-page') return;
+  if (message.source !== pageSource) return;
   if (message.type === 'DISCONNECT') {
     if (bg) {
       bg.disconnect();


### PR DESCRIPTION
As discussed in #566 and #543, Chrome added a limit on messages, so we're splitting bigger object parts into chunks. However by increasing the sate, the extension will have out-of-memory crash at some point, so in future versions we need an option to run devtools from the client part, not from devpanel or extension window.

Here we're splitting messages only from content script to the background script. There is no need to do that also from background script to devpanel after #580 is merged.