### PR TITLE
Show data in console on client part

### DIFF
--- a/src/browser/extension/inject/pageScript.js
+++ b/src/browser/extension/inject/pageScript.js
@@ -192,6 +192,25 @@ const __REDUX_DEVTOOLS_EXTENSION__ = function(reducer, preloadedState, config) {
     store.liftedStore.dispatch(action);
   }
 
+  function showInConsole(payload) {
+    /* eslint-disable no-console */
+    if (!Array.isArray(payload)) {
+      if (process.env.NODE_ENV !== 'production') console.error('Invalid payload for CONSOLE action');
+      return;
+    }
+    payload.forEach(data => {
+      if (data.groupLabel) console.group(data.groupLabel);
+      if (data.label) {
+        console.log(`%c${data.label}`, 'color: #9E9E9E; font-weight: bold', data.value);
+      } else {
+        console.log(data.value);
+      }
+      if (data.children) showInConsole(data.children);
+      if (data.groupLabel) console.groupEnd();
+    });
+    /* eslint-enable no-console */
+  }
+
   function onMessage(message) {
     switch (message.type) {
       case 'DISPATCH':
@@ -208,6 +227,9 @@ const __REDUX_DEVTOOLS_EXTENSION__ = function(reducer, preloadedState, config) {
         return;
       case 'UPDATE':
         relayState();
+        return;
+      case 'CONSOLE':
+        showInConsole(message.payload);
         return;
       case 'START':
         monitor.start(true);


### PR DESCRIPTION
It will allow in future to log actions, states and other data on client part. Specifically we need it now for [showing stack traces](https://github.com/zalmoxisus/redux-devtools-extension/issues/429#issuecomment-417955282) when `chrome.devtools.panels.openResource` is not available (for Firefox, when using not from Chrome panel, for remote debugging).