### PR TITLE
updated enhancer syntax

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For a basic [Redux store](http://redux.js.org/docs/api/createStore.html) simply 
 ```diff
  const store = createStore(
    reducer, /* preloadedState, */
-+  window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
++  window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : (f) => f
  );
 ```
 
@@ -51,7 +51,7 @@ In case ESLint is configured to not allow using the underscore dangle, wrap it l
 + /* eslint-disable no-underscore-dangle */
   const store = createStore(
    reducer, /* preloadedState, */
-   window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
+   window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : (f) => f
   );
 + /* eslint-enable */
 ```


### PR DESCRIPTION
First of all: Thank you very much for sharing this great piece of software. When somebody talk about removing redux I often argue that: *Yes, but you are going to miss the Redux Dev Tools extension* :smile: 

Using syntax in [Basic Store](https://github.com/zalmoxisus/redux-devtools-extension/tree/v2.15.0#11-basic-store) section, that is

```javascript
window.__REDUX_DEVTOOLS_EXTENSION__ && window.__REDUX_DEVTOOLS_EXTENSION__()
```

I got an error that found only on browsers that do not has this extension (e.g. Chrome on Android, Firefox, or a common user browser).

In fact that expression returns `undefined` and that is something that the `createStore()` function in my current redux version (that is for instance `v4.0.1`) raises an error.

Actually I am using TypeScript with this snippet (it should be equivalent)

```typescript
window["__REDUX_DEVTOOLS_EXTENSION__"] && window["__REDUX_DEVTOOLS_EXTENSION__"]()
```

I suggest to correct the syntax, which is by the way similar to the previous one proposed in this extension. The syntax I propose to document is the following

```javascript
window.__REDUX_DEVTOOLS_EXTENSION__ ? window.__REDUX_DEVTOOLS_EXTENSION__() : (f) => f
```