### PR TITLE
Correct possessive of "Redux"

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,7 +40,7 @@ For a basic [Redux store](http://redux.js.org/docs/api/createStore.html) simply 
  );
 ```
 
-Note that [`preloadedState`](http://redux.js.org/docs/api/createStore.html) argument is optional in Redux' [`createStore`](http://redux.js.org/docs/api/createStore.html).
+Note that [`preloadedState`](http://redux.js.org/docs/api/createStore.html) argument is optional in Redux's [`createStore`](http://redux.js.org/docs/api/createStore.html).
 
 > For universal ("isomorphic") apps, prefix it with `typeof window !== 'undefined' &&`.
 


### PR DESCRIPTION
The correct possessive form of "Redux" is "Redux's", not "Redux'".

Sources:
* https://ell.stackexchange.com/questions/6295/when-a-word-ends-in-s-or-x-do-you-add-s-or-just-an
* https://www.dictionary.com/e/how-do-you-use-an-apostrophe/