### PR TITLE
[docs] Suggest to install lib as prod dependency

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ const store = createStore(reducer, enhancer);
 
 To make things easier, there's an npm package to install:
 ```
-npm install --save-dev redux-devtools-extension
+npm install --save redux-devtools-extension
 ```
 and to use like so:
 ```js


### PR DESCRIPTION
Code of the package runs in production,
thus we should install it with `--save`, not with `--save-dev`

fixes #681