### PR TITLE
Fix composeWithDevTools declaration to enable passing storeEnhancers with various StoreExt generic type parameters

### DIFF
--- a/npm-package/index.d.ts
+++ b/npm-package/index.d.ts
@@ -165,6 +165,17 @@ export interface EnhancerOptions {
   traceLimit?: number;
 }
 
-export function composeWithDevTools<StoreExt, StateExt>(...funcs: Array<StoreEnhancer<StoreExt>>): StoreEnhancer<StoreExt>;
+type Composed<T, U extends any[]> = {
+  0: T;
+  1: ((...t: U) => any) extends ((head: infer Head, ...tail: infer Tail) => any)
+    ? Composed<Omit<T, keyof Head> & Head, Tail>
+    : never;
+}[U['length'] extends 0 ? 0 : 1];
+
+export function composeWithDevTools<StoreExtHead, StoreExtTail extends any[], StateExt>(
+    head: StoreEnhancer<StoreExtHead>,
+    ...tail: { [I in keyof StoreExtTail]: StoreEnhancer<StoreExtTail[I]> }
+): StoreEnhancer<Composed<StoreExtHead, StoreExtTail>>;
+export function composeWithDevTools(): StoreEnhancer;
 export function composeWithDevTools(options: EnhancerOptions): typeof compose;
 export function devToolsEnhancer(options: EnhancerOptions): StoreEnhancer<any>;


### PR DESCRIPTION
The current `composeWithDevTools` declaration does not accept enhancers with various `StoreExt` generic type parameters. This PR fixes this issue.

[Playground Link](https://www.typescriptlang.org/play?#code/JYWwDg9gTgLgBAbzgQzGANgTwLLACZ7oCmA7slEQDRwDGFyMRAyjNFXC2wKIB2AFsh40iUOAF84AMygQQcAEQU8AVwAe8gNwAoLaEiw4MPsp4BrKTLkByJWoC0Rk6as68RGunJFaEHgGd4ZAJgGGBfZHReASERAEYALg5WCijBYSgAHiRJExpEgAoASjgAXgA+OACoYB4Ac3EyrTcPLx9-QODQ8Mj+NJEAJkTOFN6YzKQwGTBEnmUQACMRBp0YTDBvAGFZSD8iPAyAFWoAVTgiVUYePD8UHkwAbQBdCpLELTg4AAZEg+0PhLg+XyADpQTBEsdiuVbphiudLtdAfk+EQgokapIlgAJVF4aig4EwZDAdDoniY0QHYnoKEVQSw94fOAAfjgW3AEF2+wA8iAQodqKYiJgIJI4DighUAGTi3HUKkkxpMuAzIgANxE2jE92O9ysxDqRisjzOFyIVxunxZXxVcFij20zU8FCkuS6PB8HN2AHUQnwACLqg4QCDoPwZYZELgXCV4pLcC4K9CmhE3elPagsBhRi5lfKMj4otHxkbRdIR5I5mCxsqUAtwAlEkmJJD3ACScBqcCFIrFkejMCTjyGldSYwrCcH1Pbz3EWkKI+4o3L7J2ewnKRjcpLVaTZTKjvczu8OSE7s9a99RkDauDob8RUXpb6UG0WgA9O+4AA5CBnKAyKIgh4JUlaxG0Tb+Cg6DJpMEDrLAwBEDcbiSDUeydh6-YXHAtTmiIwA0IYazeGA5DICARCMFANyimcy4iH4Wg0L4ASgWw4GvHQqKMJG+bKvkfiJPStKVHWyoIGI4lMixXpEFeAZBiGYb5KgGA4PghCkF4+SOGYhTUEEeAhGEPARGO6SxIZnSmeZDFQP0hTzjon5wAcKK0MoAHmvAsmXn6N53mGcBOuR54CGmcBwfMxAgE0R6tKeNDnn5nLyQFSn3hsXkUDwMAblWmZEowA55gSSVCXAACCAHIJgBUWSIDW5mUC47o1mTYTAB7Max8ABGw-SlLQ9C8ZW-FMoJwl3KJfjSR8knzXArlcAB0BwIsNDIMouztTheE8ARRGrOsUXkZR1G0WK5ploxcBquQmD1qlPoZbeyl+Nl3l5apaBYLgBDEGQFC6cY+nWcZ7p2bdUBWSgNndB1jnzkAA)