### PR TITLE
docs: fix link

### DIFF
--- a/README.md
+++ b/README.md
@@ -79,7 +79,7 @@ If you setup your store with [middleware and enhancers](http://redux.js.org/docs
 ```
 > Note that when the extension is not installed, we’re using Redux compose here.
   
-To specify [extension’s options](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md), use it like so:
+To specify [extension’s options](/docs/API/Arguments.md), use it like so:
 ```js
 const composeEnhancers =
   typeof window === 'object' &&
@@ -113,7 +113,7 @@ const store = createStore(reducer, composeWithDevTools(
   // other store enhancers if any
 ));
 ```
-To specify [extension’s options](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Arguments.md#windowdevtoolsextensionconfig):
+To specify [extension’s options](/docs/API/Arguments.md):
 ```js
 import { createStore, applyMiddleware } from 'redux';
 import { composeWithDevTools } from 'redux-devtools-extension';

--- a/docs/FAQ.md
+++ b/docs/FAQ.md
@@ -22,7 +22,7 @@ Just click the `Persist` button or add `?debug_session=<session_name>` to the ur
 ```js
 window.__REDUX_DEVTOOLS_EXTENSION__.open();
 ```
-Make sure to have it conditionally. Auto opening windows is a bad DX. See the [API](https://github.com/zalmoxisus/redux-devtools-extension/blob/master/docs/API/Methods.md#open) for details.
+Make sure to have it conditionally. Auto opening windows is a bad DX. See the [API](/docs/API/Methods.md#open) for details.
 #### How to enable/disable errors notifying
 Just find `Redux DevTools` on the extensions page (`chrome://extensions/`) and click the `Options` link to customize everything. The errors notifying is disabled by default. If enabled, it works only when the store enhancer is called (in order not to show notifications for any sites you visit). In case you want notifications for a non-redux app, init it explicitly by calling `window.__REDUX_DEVTOOLS_EXTENSION__.notifyErrors()` (probably you'll check if `window.__REDUX_DEVTOOLS_EXTENSION__` exists before calling it).
 #### How to get it work with WebWorkers, React Native, hybrid, desktop and server side apps


### PR DESCRIPTION
Currently it goes to the repository, not the documentation.