### PR TITLE
Remove `any` type from `StoreEnhancer` type argument

### DIFF
--- a/npm-package/index.d.ts
+++ b/npm-package/index.d.ts
@@ -167,4 +167,4 @@ export interface EnhancerOptions {
 
 export function composeWithDevTools<StoreExt, StateExt>(...funcs: Array<StoreEnhancer<StoreExt>>): StoreEnhancer<StoreExt>;
 export function composeWithDevTools(options: EnhancerOptions): typeof compose;
-export function devToolsEnhancer(options: EnhancerOptions): StoreEnhancer<any>;
+export function devToolsEnhancer(options: EnhancerOptions): StoreEnhancer;


### PR DESCRIPTION
This fixes the following problem:

```ts
// This has type `any`! ❌
const x = createStore((s) => s, {}, devToolsEnhancer({}));
```